### PR TITLE
Update README with GitHub repository URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ graph TD
 ### **Step 1: Project Setup**
 ```bash
 # Clone the repository
-git clone <your-repository-url>
+git clone https://github.com/macharpe/cloudflare-access-sso-worker.git
 cd cloudflare-access-sso-worker
 
 # Install dependencies
@@ -474,10 +474,14 @@ wrangler d1 execute training-completion-status-db --remote \
 - [Cloudflare D1 Database](https://developers.cloudflare.com/d1/)
 - [Cloudflare Zero Trust](https://developers.cloudflare.com/cloudflare-one/)
 
+### **GitHub Repository**
+- **Repository**: [https://github.com/macharpe/cloudflare-access-sso-worker](https://github.com/macharpe/cloudflare-access-sso-worker)
+- **Issues & Support**: [GitHub Issues](https://github.com/macharpe/cloudflare-access-sso-worker/issues)
+- **Cloudflare Integration**: Repository is linked to the Cloudflare Worker for automatic deployments
+
 ### **Community & Support**
 - [Cloudflare Community Forum](https://community.cloudflare.com/)
 - [Cloudflare Discord](https://discord.gg/cloudflaredev)
-- [GitHub Issues](https://github.com/your-org/cloudflare-access-sso-worker/issues)
 
 ---
 
@@ -486,7 +490,7 @@ wrangler d1 execute training-completion-status-db --remote \
 ### **Quick Start for Development**
 ```bash
 # Clone and setup
-git clone <repository-url>
+git clone https://github.com/macharpe/cloudflare-access-sso-worker.git
 cd cloudflare-access-sso-worker
 npm install
 


### PR DESCRIPTION
## Summary
- Replace placeholder repository URLs with actual GitHub repo URL
- Add dedicated GitHub Repository section with integration details  
- Update GitHub Issues link to point to correct repository
- Document that repository is linked to Cloudflare Worker for automatic deployments

## Changes Made
- Updated `git clone` commands with actual repository URL
- Added GitHub repository section under Resources & Support
- Fixed GitHub Issues link to point to correct repository
- Added note about Cloudflare Worker integration for automatic deployments

## Test Plan
- [x] Verify all repository URLs are correct and accessible
- [x] Confirm documentation reflects current GitHub setup
- [x] Ensure no placeholder URLs remain in documentation

🤖 Generated with [Claude Code](https://claude.ai/code)