### PR TITLE
Fix wrangler.jsonc configuration errors causing deployment failure

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -44,50 +44,10 @@
     "mode": "smart"
   },
 
-  // Rate Limiting for API protection
+  // CPU limits for resource protection
   "limits": {
     "cpu_ms": 50
-  },
-
-  // Rate limiting rules to protect all endpoints
-  "rules": [
-    {
-      "type": "rate_limit",
-      "value": {
-        "threshold": 100,
-        "period": 60,
-        "action": "block",
-        "match": "/*",
-        "characteristics": ["ip.src"],
-        "counting_expression": "",
-        "mitigation_timeout": 300
-      }
-    },
-    {
-      "type": "rate_limit", 
-      "value": {
-        "threshold": 20,
-        "period": 60,
-        "action": "block", 
-        "match": "/admin*",
-        "characteristics": ["ip.src"],
-        "counting_expression": "",
-        "mitigation_timeout": 600
-      }
-    },
-    {
-      "type": "rate_limit",
-      "value": {
-        "threshold": 50,
-        "period": 60,
-        "action": "block",
-        "match": "/api/*",
-        "characteristics": ["ip.src"], 
-        "counting_expression": "",
-        "mitigation_timeout": 300
-      }
-    }
-  ]
+  }
 
   // Secrets Configuration (use wrangler secret put commands):
   // 


### PR DESCRIPTION
## Summary
- Remove invalid rate limiting rules configuration causing wrangler deployment errors
- Keep CPU limits for resource protection (valid configuration)
- Fix configuration format issues that prevented successful deployment

## Problem
The previous rate limiting configuration used an invalid format for Workers:
- `rules` array with `rate_limit` type is not supported in wrangler.jsonc
- `match` patterns should be `globs` arrays
- This configuration format is for zone-level rules, not Worker-level

## Solution
- Removed invalid `rules` configuration
- Kept valid `limits.cpu_ms` for resource protection
- Deployment should now succeed

## Alternative Rate Limiting Options
For proper rate limiting, use:
1. **Zone-level WAF rules** (via Cloudflare dashboard)
2. **Worker-level implementation** (using KV storage for request tracking)
3. **Cloudflare Rate Limiting API** (for advanced rules)

🤖 Generated with [Claude Code](https://claude.ai/code)