### PR TITLE
Move OKTA_DOMAIN from secrets to environment variables and update wrangler

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,18 @@ The `wrangler.jsonc` file contains all the configuration for your Worker includi
    - Users (`okta.users.read`)
    - Groups (`okta.groups.read`)
 
-#### **Configure Secrets**
+#### **Configure Environment Variables and Secrets**
+
+**Environment Variables** (in `wrangler.jsonc` vars section):
+```json
+"vars": {
+  "OKTA_DOMAIN": "your-okta-domain.okta.com"
+}
+```
+
+**Secrets**:
 ```bash
 # Required: Okta integration (if using)
-wrangler secret put OKTA_DOMAIN      # e.g., "dev-12345.okta.com"
 wrangler secret put OKTA_API_TOKEN   # Your Okta API token from above
 
 # Required: Access application audience (from Zero Trust Dashboard)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "prettier": "^3.6.2",
-        "wrangler": "^4.27.0"
+        "wrangler": "^4.28.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -27,14 +27,14 @@
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.5.0.tgz",
-      "integrity": "sha512-CZe9B2VbjIQjBTyc+KoZcN1oUcm4T6GgCXoel9O7647djHuSRAa6sM6G+NdxWArATZgeMMbsvn9C50GCcnIatA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.6.0.tgz",
+      "integrity": "sha512-h7Txw0WbDuUbrvZwky6+x7ft+U/Gppfn/rWx6IdR+e9gjygozRJnV26Y2TOr3yrIFa6OsZqqR2lN+jWTrakHXg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.19",
-        "workerd": "^1.20250722.0"
+        "workerd": "^1.20250802.0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250730.0.tgz",
-      "integrity": "sha512-X3egNyTjLQaECYe34x8Al7r4oXAhcN3a8+8qcpNCcq1sgtuHIeAwS9potgRR/mwkGfmrJn7nfAyDKC4vrkniQQ==",
+      "version": "1.20250803.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250803.0.tgz",
+      "integrity": "sha512-6QciMnJp1p3F1qUiN0LaLfmw7SuZA/gfUBOe8Ft81pw16JYZ3CyiqIKPJvc1SV8jgDx8r+gz/PRi1NwOMt329A==",
       "cpu": [
         "x64"
       ],
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250730.0.tgz",
-      "integrity": "sha512-/4bvcaGY/9v0rghgKboGiyPKKGQTbDnQ1EeY0oN0SSQH0Cp3OBzqwni/JRvh8TEaD+5azJnSFLlFZj9w7fo+hw==",
+      "version": "1.20250803.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250803.0.tgz",
+      "integrity": "sha512-DoIgghDowtqoNhL6OoN/F92SKtrk7mRQKc4YSs/Dst8IwFZq+pCShOlWfB0MXqHKPSoiz5xLSrUKR9H6gQMPvw==",
       "cpu": [
         "arm64"
       ],
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250730.0.tgz",
-      "integrity": "sha512-I4ZsXYdNkqkJnzNFKADMufiLIzRdIRsN7dSH8UCPw2fYp1BbKA10AkKVqitFwBxIY8eOzQ6Vf7c41AjLQmtJqA==",
+      "version": "1.20250803.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250803.0.tgz",
+      "integrity": "sha512-mYdz4vNWX3+PoqRjssepVQqgh42IBiSrl+wb7vbh7VVWUVzBnQKtW3G+UFiBF62hohCLexGIEi7L0cFfRlcKSQ==",
       "cpu": [
         "x64"
       ],
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250730.0.tgz",
-      "integrity": "sha512-tTpO6139jFQ5vxgtBZgS8Y8R1jVidS4n7s37x5xO9bCWLZoL0kTj38UGZ8FENkTeaMxE9Mm//nbQol7TfJ2nZg==",
+      "version": "1.20250803.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250803.0.tgz",
+      "integrity": "sha512-RmrtUYLRUg6djKU7Z6yebS6YGJVnaDVY6bbXca+2s26vw4ibJDOTPLuBHFQF62Grw3fAfsNbjQh5i14vG2mqUg==",
       "cpu": [
         "arm64"
       ],
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250730.0.tgz",
-      "integrity": "sha512-paVHgocuilMzOU+gEyKR/86j/yI+QzmSHRnqdd8OdQ37Hf6SyPX7kQj6VVNRXbzVHWix1WxaJsXfTGK1LK05wA==",
+      "version": "1.20250803.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250803.0.tgz",
+      "integrity": "sha512-uLV8gdudz36o9sUaAKbBxxTwZwLFz1KyW7QpBvOo4+r3Ib8yVKXGiySIMWGD7A0urSMrjf3e5LlLcJKgZUOjMA==",
       "cpu": [
         "x64"
       ],
@@ -1259,9 +1259,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20250730.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250730.0.tgz",
-      "integrity": "sha512-avGXBStHQSqcJr8ra1mJ3/OQvnLZ49B1uAILQapAha1DHNZZvXWLIgUVre/WGY6ZOlNGFPh5CJ+dXLm4yuV3Jw==",
+      "version": "4.20250803.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250803.0.tgz",
+      "integrity": "sha512-1tmCLfmMw0SqRBF9PPII9CVLQRzOrO7uIBmSng8BMSmtgs2kos7OeoM0sg6KbR9FrvP/zAniLyZuCAMAjuu4fQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1273,7 +1273,7 @@
         "sharp": "^0.33.5",
         "stoppable": "1.1.0",
         "undici": "^7.10.0",
-        "workerd": "1.20250730.0",
+        "workerd": "1.20250803.0",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10",
         "zod": "3.22.3"
@@ -1397,9 +1397,9 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
-      "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.1.0.tgz",
+      "integrity": "sha512-GBuewsPrhJPftT+fqDa9oI/zc5HNsG9nREqwzoSFDOIqf0NggOZbHQj2TE1P1CDJK8ZogFnlZY9hWoUiur7I/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1449,9 +1449,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20250730.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250730.0.tgz",
-      "integrity": "sha512-w6e0WM2YGfYQGmg0dewZeLUYIxAzMYK1R31vaS4HHHjgT32Xqj0eVQH+leegzY51RZPNCvw5pe8DFmW4MGf8Fg==",
+      "version": "1.20250803.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250803.0.tgz",
+      "integrity": "sha512-oYH29mE/wNolPc32NHHQbySaNorj6+KASUtOvQHySxB5mO1NWdGuNv49woxNCF5971UYceGQndY+OLT+24C3wQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1462,28 +1462,28 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250730.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250730.0",
-        "@cloudflare/workerd-linux-64": "1.20250730.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250730.0",
-        "@cloudflare/workerd-windows-64": "1.20250730.0"
+        "@cloudflare/workerd-darwin-64": "1.20250803.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250803.0",
+        "@cloudflare/workerd-linux-64": "1.20250803.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250803.0",
+        "@cloudflare/workerd-windows-64": "1.20250803.0"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.27.0.tgz",
-      "integrity": "sha512-YNHZyMNWebFt9jD6dc20tQrCmnSzJj3SoB0FFa90w11Cx4lbP3d+rUZYjb18Zt+OGSMay1wT2PzwT2vCTskkmg==",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.28.0.tgz",
+      "integrity": "sha512-y0yHIuScpok9oSErLqDbxkBChC2+/jZpvqMg2NxOto1JCyUtDUuKljOfcVMaI48d9GuhOCSoWSumYxLAHNxaLA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
-        "@cloudflare/unenv-preset": "2.5.0",
+        "@cloudflare/unenv-preset": "2.6.0",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.25.4",
-        "miniflare": "4.20250730.0",
+        "miniflare": "4.20250803.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.19",
-        "workerd": "1.20250730.0"
+        "workerd": "1.20250803.0"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -1496,7 +1496,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250730.0"
+        "@cloudflare/workers-types": "^4.20250803.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "license": "MIT",
   "devDependencies": {
     "prettier": "^3.6.2",
-    "wrangler": "^4.27.0"
+    "wrangler": "^4.28.0"
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,6 +31,7 @@
   "vars": {
     "TEAM_DOMAIN": "macharpe.cloudflareaccess.com",
     "ADMIN_DOMAIN": "training-status.macharpe.com",
+    "OKTA_DOMAIN": "trial-6147933.okta.com",
     "DEBUG": false
   },
 
@@ -47,7 +48,6 @@
   // Secrets Configuration (use wrangler secret put commands):
   // 
   // Required for Okta integration:
-  // wrangler secret put OKTA_DOMAIN        // e.g., "dev-12345.okta.com"
   // wrangler secret put OKTA_API_TOKEN     // Your Okta API token
   //
   // Required for Cloudflare Access integration:


### PR DESCRIPTION
## Summary
• Move OKTA_DOMAIN from secrets to vars in wrangler.jsonc for better transparency
• Update README.md configuration instructions to reflect new approach
• Update wrangler from 4.27.0 to 4.28.0

## Test plan
- [x] Verify worker configuration loads OKTA_DOMAIN from environment variables
- [x] Confirm documentation reflects correct setup process
- [x] Test wrangler functionality with updated version