### PR TITLE
Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ tmp/
 # OS files
 .DS_Store
 Thumbs.db
+
+# Claude Code project instructions
+CLAUDE.md


### PR DESCRIPTION
## Summary
• Add CLAUDE.md to .gitignore to exclude Claude Code project instructions from version control
• Keeps repository focused on application code only

## Test plan
- [x] Verify CLAUDE.md is properly ignored by git
- [x] Confirm existing tracked files remain unaffected