### PR TITLE
Add production ready status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A **production-ready Cloudflare Worker** that implements an **External Evaluatio
 ![Workers](https://img.shields.io/badge/Cloudflare-Workers-blue?logo=cloudflare)
 ![D1 Database](https://img.shields.io/badge/Cloudflare-D1%20Database-green?logo=cloudflare)
 ![Access Integration](https://img.shields.io/badge/Cloudflare-Access%20Protected-blue?logo=cloudflare)
+![Production Ready](https://img.shields.io/badge/Status-Production%20Ready-brightgreen)
 
 ![Training Completion Dashboard Screenshot](images/dashboard-screenshot.png)
 


### PR DESCRIPTION
## Summary
- Add bright green 'Production Ready' badge to indicate stable deployment status
- Enhances project visibility and communicates deployment readiness to users
- Positioned with other Cloudflare service badges for visual consistency

## Purpose
This minor update serves as a test of the deployment pipeline after the Git history reset, ensuring that:
- GitHub integration continues to work smoothly
- Cloudflare Workers deployment triggers properly
- All CI/CD workflows function as expected

## Changes
- **README.md**: Added production ready status badge

## Test Plan
- [x] Badge displays correctly in README
- [ ] Deployment pipeline triggers successfully
- [ ] Worker deployment completes without issues