### PR TITLE
Improve KV namespace naming for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,11 @@ wrangler deploy
    - **Application name**: `Training Status Admin`
    - **Session Duration**: `24 hours`
 
-4. **Public Hostnames** (Add three entries for simplified configuration):
-   - **Entry 1**: Host: `training-status.your-domain.com`, Path: `/admin*` (covers /admin and admin interface)
-   - **Entry 2**: Host: `training-status.your-domain.com`, Path: `/api/*` (covers all API endpoints)
-   - **Entry 3**: Host: `training-status.your-domain.com`, Path: `/init-db` (for database initialization)
+4. **Public Hostnames** (Add four entries for simplified configuration):
+   - **Entry 1**: Host: `training-status.your-domain.com`, Path: `/admin` (for app launcher tile)
+   - **Entry 2**: Host: `training-status.your-domain.com`, Path: `/admin*` (covers /admin and admin interface)
+   - **Entry 3**: Host: `training-status.your-domain.com`, Path: `/api/*` (covers all API endpoints)
+   - **Entry 4**: Host: `training-status.your-domain.com`, Path: `/init-db` (for database initialization)
 
 5. **Access Policy**:
    - **Policy name**: `Training Administrators`
@@ -459,7 +460,7 @@ cd cloudflare-access-training-evaluator
 npm install
 
 # Configure infrastructure
-wrangler kv:namespace create "KV"
+wrangler kv:namespace create "external-auth-keys"
 wrangler d1 create training-completion-status-db
 
 # Update wrangler.jsonc with your actual IDs from above commands

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,11 +7,11 @@
 
   // KV Storage for RSA key pairs (automatically generated)
   // IMPORTANT: Replace with your own KV namespace ID when cloning this repository
-  // Create with: wrangler kv:namespace create "KV"
+  // Create with: wrangler kv:namespace create "external-auth-keys"
   "kv_namespaces": [
     {
       "binding": "KEY_STORAGE",
-      "id": "47a5e5e1ae424e609fc579ea01d58728"
+      "id": "1653d25211e2409a8ac19aff95ac4353"
     }
   ],
 


### PR DESCRIPTION
## Changes

- Update KV namespace name from 'KV' to 'external-auth-keys' for better self-documentation
- Create new KV namespace with descriptive name (ID: 1653d25211e2409a8ac19aff95ac4353)  
- Update wrangler.jsonc configuration with new namespace ID
- Update README.md with correct namespace creation command
- Verify worker deployment with new configuration

## Testing

✅ Dry run deployment successful
✅ Worker deployed and tested with new KV namespace
✅ All references to old 'KV' naming updated

The worker will automatically regenerate RSA keys in the new namespace on first use of the /keys endpoint.