### PR TITLE
📝 chore: add mailmap to consolidate commit attribution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+# Redirect Claude's commits to main author
+Matthieu Charpentier <macharpe@protonmail.com> Claude <noreply@anthropic.com>
+Matthieu Charpentier <macharpe@protonmail.com> claude <noreply@anthropic.com>


### PR DESCRIPTION
## Summary
Add a `.mailmap` file to consolidate commit attribution and redirect Claude's contributions to the main project author.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation/Configuration update

## Changes Made
- Added `.mailmap` file to redirect Claude's commits to Matthieu Charpentier
- This will consolidate contributor statistics in GitHub's interface
- Future git statistics will show unified authorship under the main project author

## Purpose
- Simplify contributor attribution in repository statistics
- Consolidate commit history under primary project author
- Improve project ownership clarity

## Impact
- GitHub contributor statistics will gradually reflect consolidated authorship
- Git log and blame will show unified attribution
- No functional changes to the codebase

## Checklist
- [x] Configuration follows Git mailmap standards
- [x] Self-review completed
- [x] No functional code changes
- [x] Documentation-only change