### PR TITLE
♻️ refactor: remove unused ExecutionContext parameter from admin handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ export default {
   async fetch(
     request: Request,
     env: Env,
-    ctx: ExecutionContext,
+    _ctx: ExecutionContext,
   ): Promise<Response> {
     const startTime = Date.now()
     const url = new URL(request.url)
@@ -127,7 +127,7 @@ export default {
         response = await handleAdminRequest(
           request,
           env,
-          () => handleWebInterface(env, ctx),
+          () => handleWebInterface(env),
           true,
         )
       } else if (


### PR DESCRIPTION
## Summary
This PR removes the unused `ExecutionContext` parameter from the `handleWebInterface()` call, following the CSP compliance changes that removed Workers Cache API operations.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring/Code cleanup
- [ ] Documentation update

## Changes Made
- Removed `ctx` parameter from `handleWebInterface(env, ctx)` call (now just `handleWebInterface(env)`)
- Renamed `ctx` to `_ctx` in the main `fetch()` function signature to indicate it's intentionally unused
- This is a cleanup following PR #37 that removed cache operations from the admin dashboard

## Context
In PR #37, we removed the Workers Cache API implementation from `handleWebInterface()`, which eliminated the need for the `ExecutionContext` parameter. This PR completes that cleanup by removing the unused parameter from the function call.

## Testing
- [x] Code follows project style guidelines (Prettier formatting applied)
- [x] Self-review completed
- [x] No functional changes - pure refactoring

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes
- [x] Related to PR #37 (CSP compliance)