### PR TITLE
🎨 feat: rebuild UI with Kumo design system + dark/light mode (v3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to the Cloudflare Access Training Evaluator project will be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-04-29
+
+### Added
+
+- **Dark / Light mode** across all four UI pages (Admin Dashboard, System Overview, External Eval fallback, Access Denied)
+  - Theme toggle button (moon/sun SVG) on every page
+  - Flash-prevention inline script sets `data-mode` on `<html>` before first paint
+  - Preference persisted to `localStorage`; respects `prefers-color-scheme` as default
+- **Kumo design system** — full UI rebuild using Cloudflare's Kumo semantic token system
+  - CSS custom property token set: surfaces (`canvas → base → tint`), text hierarchy, status colours, borders, shadows, radius scale
+  - `[data-mode="dark"]` overrides redefine all tokens for dark mode with no additional class logic
+  - Admin Dashboard: sticky page header with CF logo dot, stat cards, pill-style status selects, clean table with uppercase column headers, bulk-actions dark bar
+  - Card pages (System Overview, Access Denied, External Eval): centred card layout with orange/red header bar, endpoint method badges, status banners, notice boxes
+
+### Changed
+
+- Replaced all bespoke CSS with Kumo-compatible token-driven styles across `src/handlers/web.ts`, `src/handlers/index.ts`, and `src/auth/admin.ts`
+- Removed dark gradient background; replaced with neutral `--kumo-canvas` surface
+- Status badges replaced with `badge-success` / `badge-danger` pill components with animated dot
+- Bulk-actions bar now uses semi-transparent rgba tokens so it renders correctly in both modes
+- Warning notice text now uses `var(--kumo-warning)` token instead of hard-coded amber hex
+- Wrangler updated from `4.28.0` → `4.86.0`
+- Worker route `training-status.macharpe.com/*` added to `wrangler.jsonc`
+
+### Fixed
+
+- CSP `buildCSPHeader` / `createCSPHeaders` / `addCSPHeaders` updated to accept `string | string[] | null` for `scriptNonces`, enabling multiple inline script nonces per response without generating invalid CSP directives
+- Dark mode flash-prevention script now correctly allowlisted via its own nonce in the CSP `script-src` directive
+
+### Security
+
+- Flash-prevention init script uses a dedicated nonce, correctly included in the CSP `script-src` alongside the main script nonce — no `unsafe-inline` required
+
 ## [2.1.0] - 2025-10-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A **production-ready Cloudflare Worker** that implements an **External Evaluatio
 ![D1 Database](https://img.shields.io/badge/Cloudflare-D1%20Database-green?logo=cloudflare)
 ![Access Integration](https://img.shields.io/badge/Cloudflare-Access%20Protected-blue?logo=cloudflare)
 ![Production Ready](https://img.shields.io/badge/Status-Production%20Ready-brightgreen)
+![Version](https://img.shields.io/badge/Version-3.0.0-blue)
 
 ![Training Completion Dashboard Screenshot](images/dashboard-screenshot.png)
 
@@ -150,6 +151,8 @@ sequenceDiagram
 - **Real-time User Overview**: View all users with training status and access permissions
 - **One-Click Operations**: Sync users from Okta, update training status
 - **Responsive Design**: Works on desktop and mobile devices
+- **Dark / Light Mode**: Per-user theme toggle with `localStorage` persistence and `prefers-color-scheme` default across all pages
+- **Kumo Design System**: UI rebuilt on Cloudflare's Kumo semantic token system — consistent surfaces, status colours, and typography matching the Cloudflare Workers design language
 
 ### **🔄 Enterprise Identity Integration**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloudflare-access-training-worker",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloudflare-access-training-worker",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251008.0",
@@ -15,31 +15,28 @@
         "@typescript-eslint/parser": "^8.46.0",
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
-        "wrangler": "^4.28.0"
+        "wrangler": "^4.86.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.0.tgz",
-      "integrity": "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "mime": "^3.0.0"
-      },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.6.0.tgz",
-      "integrity": "sha512-h7Txw0WbDuUbrvZwky6+x7ft+U/Gppfn/rWx6IdR+e9gjygozRJnV26Y2TOr3yrIFa6OsZqqR2lN+jWTrakHXg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
-        "unenv": "2.0.0-rc.19",
-        "workerd": "^1.20250802.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -48,9 +45,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250803.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250803.0.tgz",
-      "integrity": "sha512-6QciMnJp1p3F1qUiN0LaLfmw7SuZA/gfUBOe8Ft81pw16JYZ3CyiqIKPJvc1SV8jgDx8r+gz/PRi1NwOMt329A==",
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260426.1.tgz",
+      "integrity": "sha512-Ch7DqsmYzSQRTY87pZpsGsFVz9VVBnLPnCBOHxKt1HH25a7oMu1w1PbPWqVmE0VerCLsj/TScX7Ob3v6E14TZw==",
       "cpu": [
         "x64"
       ],
@@ -65,9 +62,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250803.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250803.0.tgz",
-      "integrity": "sha512-DoIgghDowtqoNhL6OoN/F92SKtrk7mRQKc4YSs/Dst8IwFZq+pCShOlWfB0MXqHKPSoiz5xLSrUKR9H6gQMPvw==",
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260426.1.tgz",
+      "integrity": "sha512-0m0U8vaPRH25SpKjbSyRql6gmPe4rCsETRV2WW0qBnuMdKNr5Vh5/Uez80xVrfiCCRMTULGeg63Nqg2vg6CDOA==",
       "cpu": [
         "arm64"
       ],
@@ -82,9 +79,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250803.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250803.0.tgz",
-      "integrity": "sha512-mYdz4vNWX3+PoqRjssepVQqgh42IBiSrl+wb7vbh7VVWUVzBnQKtW3G+UFiBF62hohCLexGIEi7L0cFfRlcKSQ==",
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260426.1.tgz",
+      "integrity": "sha512-C8LlC8uSYzg49y51n++75esxZmMp+Uz1OKHHA/4lkv6rjOTbcHQJuEwSLppjybVIXpv7A8MBhbu9iyCTvyv1mw==",
       "cpu": [
         "x64"
       ],
@@ -99,9 +96,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250803.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250803.0.tgz",
-      "integrity": "sha512-RmrtUYLRUg6djKU7Z6yebS6YGJVnaDVY6bbXca+2s26vw4ibJDOTPLuBHFQF62Grw3fAfsNbjQh5i14vG2mqUg==",
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260426.1.tgz",
+      "integrity": "sha512-ESVp/OIFMAqjQsa8BOP2BQQz5Vpfv6ncN6lNnIuNeOgsISQBdYk+LA60bwQHMud9tvmnSYtONp1zkZ8OQz+x6w==",
       "cpu": [
         "arm64"
       ],
@@ -116,9 +113,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250803.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250803.0.tgz",
-      "integrity": "sha512-uLV8gdudz36o9sUaAKbBxxTwZwLFz1KyW7QpBvOo4+r3Ib8yVKXGiySIMWGD7A0urSMrjf3e5LlLcJKgZUOjMA==",
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260426.1.tgz",
+      "integrity": "sha512-d3Xj/IjINRgNVwH+eKhpUn4xkkcEewbWXbOvBlapiirKWh5zl9m0Epi3qOqmjyRYK6MICqIGXg4qZBEt0lxudw==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +130,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20251008.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251008.0.tgz",
-      "integrity": "sha512-dZLkO4PbCL0qcCSKzuW7KE4GYe49lI12LCfQ5y9XeSwgYBoAUbwH4gmJ6A0qUIURiTJTkGkRkhVPqpq2XNgYRA==",
+      "version": "4.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260426.1.tgz",
+      "integrity": "sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -153,9 +150,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -164,9 +161,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
-      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
       "cpu": [
         "ppc64"
       ],
@@ -181,9 +178,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
-      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
       ],
@@ -198,9 +195,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
-      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
       ],
@@ -215,9 +212,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
-      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
       ],
@@ -232,9 +229,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
-      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
       ],
@@ -249,9 +246,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
-      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
       ],
@@ -266,9 +263,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
       ],
@@ -283,9 +280,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
-      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
       ],
@@ -300,9 +297,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
-      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
       ],
@@ -317,9 +314,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
-      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
       ],
@@ -334,9 +331,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
-      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
       ],
@@ -351,9 +348,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
-      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
       ],
@@ -368,9 +365,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
-      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
       ],
@@ -385,9 +382,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
-      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
       ],
@@ -402,9 +399,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
-      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
       ],
@@ -419,9 +416,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
-      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
       ],
@@ -436,9 +433,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
-      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
       ],
@@ -453,9 +450,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
       "cpu": [
         "arm64"
       ],
@@ -470,9 +467,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
       ],
@@ -487,9 +484,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
       "cpu": [
         "arm64"
       ],
@@ -504,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
       ],
@@ -520,10 +517,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
-      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
       ],
@@ -538,9 +552,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
-      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
       ],
@@ -555,9 +569,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
-      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
       ],
@@ -572,9 +586,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
-      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
       ],
@@ -845,10 +859,20 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -865,13 +889,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -888,13 +912,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -909,9 +933,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -926,13 +950,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -943,13 +970,56 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -960,13 +1030,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -977,13 +1050,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -994,13 +1070,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1011,13 +1090,16 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1028,13 +1110,16 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1047,17 +1132,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1070,17 +1158,72 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1093,17 +1236,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1116,17 +1262,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1139,17 +1288,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1162,13 +1314,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
@@ -1176,8 +1328,28 @@
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.7.0"
       },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1186,9 +1358,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -1206,9 +1378,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -1236,9 +1408,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -1292,9 +1464,9 @@
       }
     },
     "node_modules/@poppinss/colors": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.5.tgz",
-      "integrity": "sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1302,9 +1474,9 @@
       }
     },
     "node_modules/@poppinss/dumper": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.4.tgz",
-      "integrity": "sha512-iG0TIdqv8xJ3Lt9O8DrPRxw1MRLjNpoqiSGU03P/wNLP/s0ra0udPJ1J2Tx5M0J3H/cVyEgpbn8xUKRY9j59kQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1314,16 +1486,16 @@
       }
     },
     "node_modules/@poppinss/exception": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.2.tgz",
-      "integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.0.2.tgz",
-      "integrity": "sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1334,9 +1506,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.7.tgz",
-      "integrity": "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1607,6 +1779,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1623,16 +1796,6 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -1758,26 +1921,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1790,18 +1940,8 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1812,13 +1952,17 @@
       "peer": true
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -1863,17 +2007,10 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1891,9 +2028,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
-      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1904,31 +2041,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.4",
-        "@esbuild/android-arm": "0.25.4",
-        "@esbuild/android-arm64": "0.25.4",
-        "@esbuild/android-x64": "0.25.4",
-        "@esbuild/darwin-arm64": "0.25.4",
-        "@esbuild/darwin-x64": "0.25.4",
-        "@esbuild/freebsd-arm64": "0.25.4",
-        "@esbuild/freebsd-x64": "0.25.4",
-        "@esbuild/linux-arm": "0.25.4",
-        "@esbuild/linux-arm64": "0.25.4",
-        "@esbuild/linux-ia32": "0.25.4",
-        "@esbuild/linux-loong64": "0.25.4",
-        "@esbuild/linux-mips64el": "0.25.4",
-        "@esbuild/linux-ppc64": "0.25.4",
-        "@esbuild/linux-riscv64": "0.25.4",
-        "@esbuild/linux-s390x": "0.25.4",
-        "@esbuild/linux-x64": "0.25.4",
-        "@esbuild/netbsd-arm64": "0.25.4",
-        "@esbuild/netbsd-x64": "0.25.4",
-        "@esbuild/openbsd-arm64": "0.25.4",
-        "@esbuild/openbsd-x64": "0.25.4",
-        "@esbuild/sunos-x64": "0.25.4",
-        "@esbuild/win32-arm64": "0.25.4",
-        "@esbuild/win32-ia32": "0.25.4",
-        "@esbuild/win32-x64": "0.25.4"
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2186,26 +2324,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/exit-hook": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
-      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/exsolve": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
-      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2367,13 +2485,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2444,13 +2555,6 @@
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2616,38 +2720,19 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/miniflare": {
-      "version": "4.20250803.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250803.0.tgz",
-      "integrity": "sha512-1tmCLfmMw0SqRBF9PPII9CVLQRzOrO7uIBmSng8BMSmtgs2kos7OeoM0sg6KbR9FrvP/zAniLyZuCAMAjuu4fQ==",
+      "version": "4.20260426.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260426.0.tgz",
+      "integrity": "sha512-KM+v76d04qT+NsPfVKVQEgnnuLNE3uzCCl2QKMTJ5OXor5JbBm1vpkQwQ+l7o5ELCrZ74RnyKhJKLiJyUA39Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "acorn": "8.14.0",
-        "acorn-walk": "8.3.2",
-        "exit-hook": "2.2.1",
-        "glob-to-regexp": "0.4.1",
-        "sharp": "^0.33.5",
-        "stoppable": "1.1.0",
-        "undici": "^7.10.0",
-        "workerd": "1.20250803.0",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260426.1",
         "ws": "8.18.0",
-        "youch": "4.1.0-beta.10",
-        "zod": "3.22.3"
+        "youch": "4.1.0-beta.10"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -2683,13 +2768,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2915,9 +2993,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2928,16 +3006,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -2946,25 +3024,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {
@@ -2992,27 +3075,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4",
-        "npm": ">=6"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3028,9 +3090,9 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.1.0.tgz",
-      "integrity": "sha512-GBuewsPrhJPftT+fqDa9oI/zc5HNsG9nREqwzoSFDOIqf0NggOZbHQj2TE1P1CDJK8ZogFnlZY9hWoUiur7I/A==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3102,17 +3164,10 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.13.0.tgz",
-      "integrity": "sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3127,17 +3182,13 @@
       "license": "MIT"
     },
     "node_modules/unenv": {
-      "version": "2.0.0-rc.19",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.19.tgz",
-      "integrity": "sha512-t/OMHBNAkknVCI7bVB9OWjUUAwhVv9vsPIAGnNUxnu3FxPQN11rjh0sksLMzc3g7IlTgvHmOTl4JM7JHpcv5wA==",
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "exsolve": "^1.0.7",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "ufo": "^1.6.1"
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/uri-js": {
@@ -3180,9 +3231,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20250803.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250803.0.tgz",
-      "integrity": "sha512-oYH29mE/wNolPc32NHHQbySaNorj6+KASUtOvQHySxB5mO1NWdGuNv49woxNCF5971UYceGQndY+OLT+24C3wQ==",
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260426.1.tgz",
+      "integrity": "sha512-ELvGgN8c9oo+E6EPyecxk1TEf6/eAK4TxxQTW5mQ87C7jbjCzhMbg0P2ije49UBHV0dkBYPJcJvcklUltipl2A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3193,41 +3244,41 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250803.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250803.0",
-        "@cloudflare/workerd-linux-64": "1.20250803.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250803.0",
-        "@cloudflare/workerd-windows-64": "1.20250803.0"
+        "@cloudflare/workerd-darwin-64": "1.20260426.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260426.1",
+        "@cloudflare/workerd-linux-64": "1.20260426.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260426.1",
+        "@cloudflare/workerd-windows-64": "1.20260426.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.28.0.tgz",
-      "integrity": "sha512-y0yHIuScpok9oSErLqDbxkBChC2+/jZpvqMg2NxOto1JCyUtDUuKljOfcVMaI48d9GuhOCSoWSumYxLAHNxaLA==",
+      "version": "4.86.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.86.0.tgz",
+      "integrity": "sha512-9aa/gbF/HiUeeUEwyQpW5LDPBEzyt7iaE6xHwm0vk2Ly8A6J+jh03pzchqVnCCWR832mNyA28MD8oAYt0Kfvlw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.0",
-        "@cloudflare/unenv-preset": "2.6.0",
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.25.4",
-        "miniflare": "4.20250803.0",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260426.0",
         "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.19",
-        "workerd": "1.20250803.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260426.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.3.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250803.0"
+        "@cloudflare/workers-types": "^4.20260426.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -3294,16 +3345,6 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "cloudflare-access-training-worker",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Production-ready Cloudflare Worker implementing External Evaluation Rule for training-based access control with Zero Trust",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,6 @@
     "@typescript-eslint/parser": "^8.46.0",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
-    "wrangler": "^4.28.0"
+    "wrangler": "^4.86.0"
   }
 }

--- a/src/auth/admin.ts
+++ b/src/auth/admin.ts
@@ -35,178 +35,166 @@ export function createUnauthorizedHtmlResponse(): Response {
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Access Denied - Training Admin</title>
+  <title>Access Denied — Training Admin</title>
+  <script>(function(){var s=localStorage.getItem('ui-mode');var d=window.matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.setAttribute('data-mode',s||(d?'dark':'light'));})();</script>
   <style>
-    /* Reset */
-    * { margin:0; padding:0; box-sizing:border-box; }
-
-    /* Professional Design System - Gateway Style */
-    :root{
-      --accent: #F38020;         /* Cloudflare Orange */
-      --cta: #2563EB;            /* Blue CTA */
-      --cta-hover: #1E40AF;
-      --surface: #ffffff;        /* Card & modal surface */
-      --muted: #6B7280;          /* Muted text */
-      --border: #E5E7EB;         /* Subtle borders */
-      --panel: #F8FAFC;          /* Light panels inside card */
-      --shadow: 0 12px 30px rgba(2,6,23,.18);
-      --radius: 16px;
-      --text-primary: #111827;
-      --text-secondary: #374151;
+    :root {
+      --kumo-canvas:   #f6f8fa; --kumo-base: #ffffff; --kumo-tint: #f6f8fa;
+      --kumo-hairline: #e5e7eb; --kumo-border: #d1d5db;
+      --kumo-text-default: #111827; --kumo-text-strong: #374151;
+      --kumo-text-subtle: #6b7280; --kumo-text-inactive: #9ca3af;
+      --kumo-danger: #dc2626; --kumo-danger-tint: #fee2e2; --kumo-danger-border: #fecaca;
+      --kumo-info: #2563eb; --kumo-info-tint: #dbeafe; --kumo-info-border: #bfdbfe;
+      --kumo-shadow-lg: 0 10px 30px rgba(0,0,0,.10), 0 2px 6px rgba(0,0,0,.05);
+      --kumo-radius: 8px; --kumo-radius-lg: 12px; --kumo-radius-xl: 16px;
+      --kumo-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      --kumo-font-mono: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    }
+    [data-mode="dark"] {
+      --kumo-canvas: #0f1117; --kumo-base: #1a1d27; --kumo-tint: #22263a;
+      --kumo-hairline: rgba(255,255,255,.08); --kumo-border: rgba(255,255,255,.14);
+      --kumo-text-default: #f3f4f6; --kumo-text-strong: #d1d5db;
+      --kumo-text-subtle: #9ca3af; --kumo-text-inactive: #6b7280;
+      --kumo-danger-tint: rgba(220,38,38,.15); --kumo-danger-border: rgba(220,38,38,.35);
+      --kumo-info-tint: rgba(37,99,235,.15); --kumo-info-border: rgba(37,99,235,.35);
+      --kumo-shadow-lg: 0 10px 30px rgba(0,0,0,.5), 0 2px 6px rgba(0,0,0,.3);
     }
 
-    body{
-      font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,sans-serif;
-      background: radial-gradient(1200px 800px at 50% -10%, #111827 0%, #0f172a 60%);
-      min-height:100vh;
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      color: var(--text-primary);
-      line-height:1.6;
-      -webkit-font-smoothing:antialiased;
-      -moz-osx-font-smoothing:grayscale;
-      padding: 24px;
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: var(--kumo-font); background: var(--kumo-canvas); min-height: 100vh;
+      display: flex; align-items: center; justify-content: center;
+      color: var(--kumo-text-default); line-height: 1.5;
+      -webkit-font-smoothing: antialiased; padding: 24px;
+      transition: background 0.2s, color 0.2s;
     }
 
-    .container{
-      background:var(--surface);
-      border-radius:var(--radius);
-      box-shadow:var(--shadow);
-      max-width:720px;
-      width:100%;
-      margin:0;
-      overflow:hidden;
+    .card {
+      background: var(--kumo-base); border: 1px solid var(--kumo-hairline);
+      border-radius: var(--kumo-radius-xl); box-shadow: var(--kumo-shadow-lg);
+      max-width: 520px; width: 100%; overflow: hidden;
     }
 
-    .header{
-      background:var(--accent);
-      color:#fff;
-      padding:28px 28px 24px;
-      text-align:center;
+    .card-header {
+      background: var(--kumo-danger); padding: 28px 28px 22px;
+      text-align: center; color: #fff; position: relative;
+    }
+    .card-header-icon { display: block; font-size: 36px; margin-bottom: 12px; line-height: 1; }
+    .card-header h1   { font-size: 22px; font-weight: 700; margin-bottom: 4px; }
+    .card-header p    { font-size: 13px; opacity: 0.92; }
+
+    .card-body { padding: 22px 24px; display: flex; flex-direction: column; gap: 16px; }
+
+    .info-panel {
+      background: var(--kumo-tint); border: 1px solid var(--kumo-hairline);
+      border-radius: var(--kumo-radius-lg); padding: 16px 18px;
+    }
+    .info-panel-title { font-size: 14px; font-weight: 700; color: var(--kumo-text-default); margin-bottom: 8px; }
+    .info-panel p { font-size: 14px; color: var(--kumo-text-strong); line-height: 1.55; }
+
+    .hint-box {
+      background: var(--kumo-info-tint); border: 1px solid var(--kumo-info-border);
+      border-radius: var(--kumo-radius); padding: 12px 14px;
+      font-size: 13px; color: var(--kumo-text-strong); line-height: 1.5;
+      display: flex; align-items: flex-start; gap: 10px;
+    }
+    .hint-box-icon { font-size: 14px; flex-shrink: 0; margin-top: 1px; }
+    .hint-box strong { font-weight: 600; }
+    .hint-box code {
+      font-family: var(--kumo-font-mono); font-size: 12px;
+      background: rgba(37,99,235,.1); border: 1px solid var(--kumo-info-border);
+      border-radius: 4px; padding: 1px 6px;
     }
 
-    .header .icon{
-      font-size:40px;
-      display:block;
-      margin-bottom:12px;
-      line-height:1;
+    .info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; }
+    .info-tile {
+      background: var(--kumo-tint); border: 1px solid var(--kumo-hairline);
+      border-radius: var(--kumo-radius-lg); padding: 14px 16px;
     }
-
-    .header h1{
-      font-size:28px;
-      font-weight:700;
-      letter-spacing:.2px;
-      margin-bottom:6px;
+    .info-tile-label {
+      font-size: 11px; font-weight: 600; color: var(--kumo-text-subtle);
+      text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 6px;
     }
+    .info-tile-value { font-size: 13px; color: var(--kumo-text-strong); line-height: 1.45; }
 
-    .header p{
-      font-size:14px;
-      opacity:.95;
+    .card-footer {
+      border-top: 1px solid var(--kumo-hairline); padding: 12px 24px;
+      text-align: center; background: var(--kumo-tint);
     }
+    .card-footer span { font-size: 12px; color: var(--kumo-text-inactive); font-weight: 500; }
 
-    .content{
-      padding:28px;
+    /* Theme toggle */
+    .theme-toggle {
+      position: absolute; top: 12px; right: 12px;
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 30px; height: 30px; border-radius: var(--kumo-radius);
+      background: rgba(255,255,255,.2); border: 1px solid rgba(255,255,255,.3);
+      color: #fff; cursor: pointer; transition: background 0.15s;
     }
+    .theme-toggle:hover { background: rgba(255,255,255,.35); }
+    .theme-toggle svg { pointer-events: none; }
+    .icon-sun { display: none; } .icon-moon { display: block; }
+    [data-mode="dark"] .icon-sun { display: block; } [data-mode="dark"] .icon-moon { display: none; }
 
-    .auth-info{
-      background:var(--panel);
-      border:1px solid var(--border);
-      border-radius:12px;
-      padding:16px 18px;
-      margin-bottom: 18px;
-    }
-
-    .auth-title{
-      font-weight:700;
-      font-size:16px;
-      color: var(--text-primary);
-      margin-bottom:6px;
-    }
-
-    .auth-info p{
-      font-size:14px;
-      color: var(--text-secondary);
-      margin-bottom: 10px;
-    }
-
-    .admin-access{
-      margin:18px 0 0;
-      padding:14px 16px;
-      background: #EFF6FF;
-      border:1px solid #DBEAFE;
-      border-radius:10px;
-      font-size:14px;
-      color: var(--text-primary);
-    }
-
-    .admin-access strong{
-      font-weight:600;
-      font-size:14px;
-    }
-
-    .info-boxes {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 16px;
-      margin-top: 18px;
-    }
-
-    .info-box {
-      background: var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 18px;
-    }
-
-    .info-box-title {
-      font-weight: 600;
-      color: var(--text-primary);
-      font-size: 14px;
-      margin-bottom: 8px;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-    }
-
-    .info-box-content {
-      font-size: 14px;
-      color: var(--text-secondary);
-      line-height: 1.5;
-    }
-
-    @media (max-width:600px){
-      .container{ margin:12px; }
-      .content{ padding:22px; }
-      .header{ padding:24px; }
-      .header h1{ font-size:24px; }
-      .info-boxes {
-        grid-template-columns: 1fr;
-      }
+    @media (max-width: 560px) {
+      body { padding: 16px; }
+      .card-header { padding: 22px 18px 18px; }
+      .card-body   { padding: 18px; }
+      .info-grid   { grid-template-columns: 1fr; }
     }
   </style>
 </head>
 <body>
-  <div class="container">
-    <div class="header">
-      <span class="icon">🔒</span>
+  <div class="card">
+    <div class="card-header">
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark/light mode">
+        <svg class="icon-sun" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        <svg class="icon-moon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      </button>
+      <span class="card-header-icon" aria-hidden="true">🔒</span>
       <h1>Access Denied</h1>
       <p>Training Admin Authentication Required</p>
     </div>
 
-    <div class="content">
-      <div class="auth-info">
-        <div class="auth-title">Cloudflare Access Authentication Required</div>
-        <p>This admin interface is protected by Cloudflare Access authentication. Please ensure you are logged in through your SSO provider to access the training management system.</p>
+    <div class="card-body">
+      <div class="info-panel">
+        <p class="info-panel-title">Cloudflare Access Authentication Required</p>
+        <p>This admin interface is protected by Cloudflare Access. Please ensure you are authenticated through your SSO provider before accessing the training management system.</p>
+      </div>
 
-        <div class="admin-access">
-          <strong>Admin Interface:</strong> Once authenticated, access the full training dashboard at <code style="background: #F3F4F6; padding: 2px 6px; border-radius: 4px; font-family: monospace;">/admin</code>
+      <div class="hint-box">
+        <span class="hint-box-icon">ℹ️</span>
+        <p><strong>Admin access:</strong> Once authenticated, navigate to <code>/admin</code> to open the training management dashboard.</p>
+      </div>
+
+      <div class="info-grid">
+        <div class="info-tile">
+          <p class="info-tile-label">Protection</p>
+          <p class="info-tile-value">Cloudflare Access with SSO</p>
+        </div>
+        <div class="info-tile">
+          <p class="info-tile-label">Required Role</p>
+          <p class="info-tile-value">Training Administrator</p>
         </div>
       </div>
     </div>
+
+    <div class="card-footer">
+      <span>Powered by Cloudflare Workers</span>
+    </div>
   </div>
+
+  <script>
+    document.getElementById('themeToggle').addEventListener('click', function() {
+      var next = document.documentElement.getAttribute('data-mode') === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-mode', next);
+      localStorage.setItem('ui-mode', next);
+    });
+  </script>
 </body>
 </html>
-  `
+`
 
   return new Response(html, {
     status: 401,

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -101,118 +101,184 @@ export async function handleExternalEvaluationRequest(
   // Handle browser GET requests with a friendly response
   if (request.method === 'GET') {
     const styleNonce = generateNonce()
+    const scriptNonce = generateNonce()
+    const initNonce = generateNonce()
     const html = `
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Training Compliance Gateway</title>
-    <style nonce="${styleNonce}">
-        body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 50%, #90caf9 100%);
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin: 0;
-            padding: 20px;
-        }
-        .container {
-            background: white;
-            padding: 40px;
-            border-radius: 12px;
-            box-shadow: 0 8px 32px rgba(0,0,0,0.1);
-            text-align: center;
-            max-width: 600px;
-        }
-        .header {
-            color: #1976d2;
-            font-size: 3rem;
-            margin-bottom: 20px;
-        }
-        h1 {
-            color: #333;
-            margin-bottom: 20px;
-            font-size: 2rem;
-        }
-        p {
-            color: #666;
-            margin-bottom: 20px;
-            line-height: 1.6;
-        }
-        .status {
-            background: #e8f5e8;
-            color: #2e7d32;
-            padding: 15px;
-            border-radius: 8px;
-            margin: 20px 0;
-            border-left: 4px solid #4caf50;
-            font-weight: 600;
-        }
-        .endpoints {
-            background: #f5f5f5;
-            padding: 20px;
-            border-radius: 8px;
-            margin: 20px 0;
-            text-align: left;
-        }
-        .endpoints h3 {
-            color: #1976d2;
-            margin-top: 0;
-        }
-        .endpoint {
-            font-family: monospace;
-            background: white;
-            padding: 8px 12px;
-            margin: 8px 0;
-            border-radius: 4px;
-            border-left: 3px solid #2196f3;
-        }
-        .note {
-            background: #fff3e0;
-            color: #e65100;
-            padding: 15px;
-            border-radius: 8px;
-            border-left: 4px solid #ff9800;
-            text-align: left;
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Training Compliance Gateway</title>
+  <script nonce="${initNonce}">(function(){var s=localStorage.getItem('ui-mode');var d=window.matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.setAttribute('data-mode',s||(d?'dark':'light'));})();</script>
+  <style nonce="${styleNonce}">
+    :root {
+      --kumo-canvas:   #f6f8fa; --kumo-base: #ffffff; --kumo-tint: #f6f8fa;
+      --kumo-hairline: #e5e7eb; --kumo-border: #d1d5db; --kumo-orange: #f38020;
+      --kumo-text-default: #111827; --kumo-text-subtle: #6b7280; --kumo-text-inactive: #9ca3af;
+      --kumo-success: #16a34a; --kumo-success-tint: #dcfce7; --kumo-success-border: #bbf7d0;
+      --kumo-warning: #d97706; --kumo-warning-tint: #fef3c7; --kumo-warning-border: #fde68a;
+      --kumo-info: #2563eb; --kumo-info-tint: #dbeafe; --kumo-info-border: #bfdbfe;
+      --kumo-danger: #dc2626; --kumo-danger-tint: #fee2e2; --kumo-danger-border: #fecaca;
+      --kumo-shadow-lg: 0 10px 30px rgba(0,0,0,.10), 0 2px 6px rgba(0,0,0,.05);
+      --kumo-radius: 8px; --kumo-radius-xl: 16px;
+      --kumo-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      --kumo-font-mono: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    }
+    [data-mode="dark"] {
+      --kumo-canvas: #0f1117; --kumo-base: #1a1d27; --kumo-tint: #22263a;
+      --kumo-hairline: rgba(255,255,255,.08); --kumo-border: rgba(255,255,255,.14);
+      --kumo-text-default: #f3f4f6; --kumo-text-subtle: #9ca3af; --kumo-text-inactive: #6b7280;
+      --kumo-success-tint: rgba(22,163,74,.15); --kumo-success-border: rgba(22,163,74,.35);
+      --kumo-warning-tint: rgba(217,119,6,.15); --kumo-warning-border: rgba(217,119,6,.35);
+      --kumo-info-tint: rgba(37,99,235,.15); --kumo-info-border: rgba(37,99,235,.35);
+      --kumo-danger-tint: rgba(220,38,38,.15); --kumo-danger-border: rgba(220,38,38,.35);
+      --kumo-shadow-lg: 0 10px 30px rgba(0,0,0,.5), 0 2px 6px rgba(0,0,0,.3);
+    }
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: var(--kumo-font); background: var(--kumo-canvas); min-height: 100vh;
+      display: flex; align-items: center; justify-content: center;
+      color: var(--kumo-text-default); line-height: 1.5;
+      -webkit-font-smoothing: antialiased; padding: 24px;
+      transition: background 0.2s, color 0.2s;
+    }
+    .card {
+      background: var(--kumo-base); border: 1px solid var(--kumo-hairline);
+      border-radius: var(--kumo-radius-xl); box-shadow: var(--kumo-shadow-lg);
+      max-width: 540px; width: 100%; overflow: hidden;
+    }
+    .card-header {
+      background: var(--kumo-orange); padding: 28px 28px 22px;
+      text-align: center; color: #fff; position: relative;
+    }
+    .card-header-icon { display: block; font-size: 36px; margin-bottom: 12px; line-height: 1; }
+    .card-header h1 { font-size: 20px; font-weight: 700; margin-bottom: 6px; }
+    .card-header p  { font-size: 13px; opacity: 0.92; line-height: 1.5; }
+    .card-body { padding: 22px 24px; }
+    .status-banner {
+      display: flex; align-items: center; gap: 10px; padding: 10px 14px;
+      background: var(--kumo-success-tint); border: 1px solid var(--kumo-success-border);
+      border-radius: var(--kumo-radius); margin-bottom: 20px;
+    }
+    .status-dot {
+      width: 10px; height: 10px; border-radius: 50%; background: var(--kumo-success);
+      box-shadow: 0 0 0 3px rgba(22,163,74,.2); animation: pulse 2s infinite; flex-shrink: 0;
+    }
+    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.6} }
+    .status-banner span { font-size: 14px; font-weight: 600; color: var(--kumo-success); }
+    .section-title {
+      font-size: 12px; font-weight: 600; color: var(--kumo-text-subtle);
+      text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px;
+    }
+    .endpoints { display: flex; flex-direction: column; gap: 7px; margin-bottom: 18px; }
+    .endpoint-row {
+      display: flex; align-items: center; gap: 10px; padding: 9px 12px;
+      background: var(--kumo-tint); border: 1px solid var(--kumo-hairline);
+      border-radius: var(--kumo-radius);
+    }
+    .method-badge {
+      font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 4px;
+      min-width: 40px; text-align: center; flex-shrink: 0;
+    }
+    .method-get  { background: var(--kumo-info-tint);   color: var(--kumo-info);   border: 1px solid var(--kumo-info-border); }
+    .method-post { background: var(--kumo-danger-tint); color: var(--kumo-danger); border: 1px solid var(--kumo-danger-border); }
+    .endpoint-path { font-family: var(--kumo-font-mono); font-size: 13px; font-weight: 600; min-width: 64px; flex-shrink: 0; color: var(--kumo-text-default); }
+    .endpoint-desc { font-size: 13px; color: var(--kumo-text-subtle); }
+    .notice {
+      display: flex; gap: 10px; padding: 12px 14px;
+      background: var(--kumo-warning-tint); border: 1px solid var(--kumo-warning-border);
+      border-radius: var(--kumo-radius); margin-bottom: 4px;
+    }
+    .notice-icon { font-size: 15px; flex-shrink: 0; margin-top: 1px; }
+    .notice-text { font-size: 13px; color: var(--kumo-warning); line-height: 1.5; }
+    .notice-text strong { font-weight: 600; }
+    .card-footer {
+      border-top: 1px solid var(--kumo-hairline); padding: 12px 24px;
+      text-align: center; background: var(--kumo-tint);
+    }
+    .card-footer span { font-size: 12px; color: var(--kumo-text-inactive); font-weight: 500; }
+    /* Theme toggle */
+    .theme-toggle {
+      position: absolute; top: 12px; right: 12px;
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 30px; height: 30px; border-radius: var(--kumo-radius);
+      background: rgba(255,255,255,.2); border: 1px solid rgba(255,255,255,.3);
+      color: #fff; cursor: pointer; transition: background 0.15s;
+    }
+    .theme-toggle:hover { background: rgba(255,255,255,.35); }
+    .theme-toggle svg { pointer-events: none; }
+    .icon-sun { display: none; } .icon-moon { display: block; }
+    [data-mode="dark"] .icon-sun { display: block; } [data-mode="dark"] .icon-moon { display: none; }
+    @media (max-width: 560px) {
+      body { padding: 16px; }
+      .card-header { padding: 22px 18px 18px; }
+      .card-body   { padding: 18px; }
+      .endpoint-row { flex-direction: column; align-items: flex-start; gap: 5px; }
+    }
+  </style>
 </head>
 <body>
-    <div class="container">
-        <div class="header">🛡️</div>
-        <h1>Training Compliance Gateway</h1>
-        <p>This is a <strong>Cloudflare Access External Evaluation Worker</strong> that enforces training completion requirements for Zero Trust security.</p>
-
-        <div class="status">
-            ✅ Worker is running and ready to process access requests
-        </div>
-
-        <div class="endpoints">
-            <h3>Available Endpoints:</h3>
-            <div class="endpoint">GET /keys - Public key endpoint for Cloudflare Access</div>
-            <div class="endpoint">POST / - External evaluation endpoint (used by Access)</div>
-            <div class="endpoint">GET /admin - Training management dashboard (Access protected)</div>
-        </div>
-
-        <div class="note">
-            <strong>Note:</strong> This endpoint is designed to receive POST requests with JWT tokens from Cloudflare Access.
-            Direct browser access shows this informational page instead of the JSON parsing error.
-        </div>
-
-        <p><strong>Powered by Cloudflare Workers</strong></p>
+  <div class="card">
+    <div class="card-header">
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark/light mode">
+        <svg class="icon-sun" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        <svg class="icon-moon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      </button>
+      <span class="card-header-icon" aria-hidden="true">🛡️</span>
+      <h1>Training Compliance Gateway</h1>
+      <p>Cloudflare Access External Evaluation Worker enforcing training completion for Zero Trust security.</p>
     </div>
+    <div class="card-body">
+      <div class="status-banner">
+        <div class="status-dot"></div>
+        <span>Worker is running and ready</span>
+      </div>
+      <p class="section-title">Available Endpoints</p>
+      <div class="endpoints">
+        <div class="endpoint-row">
+          <span class="method-badge method-get">GET</span>
+          <span class="endpoint-path">/keys</span>
+          <span class="endpoint-desc">Public key endpoint for Cloudflare Access</span>
+        </div>
+        <div class="endpoint-row">
+          <span class="method-badge method-post">POST</span>
+          <span class="endpoint-path">/</span>
+          <span class="endpoint-desc">External evaluation endpoint (used by Access)</span>
+        </div>
+        <div class="endpoint-row">
+          <span class="method-badge method-get">GET</span>
+          <span class="endpoint-path">/admin</span>
+          <span class="endpoint-desc">Training management dashboard (Access protected)</span>
+        </div>
+      </div>
+      <div class="notice">
+        <span class="notice-icon">⚠️</span>
+        <p class="notice-text">
+          <strong>Note:</strong> This endpoint is designed to receive POST requests with JWT tokens from Cloudflare Access. Direct browser access shows this informational page.
+        </p>
+      </div>
+    </div>
+    <div class="card-footer">
+      <span>Powered by Cloudflare Workers</span>
+    </div>
+  </div>
+  <script nonce="${scriptNonce}">
+    document.getElementById('themeToggle').addEventListener('click', function() {
+      var next = document.documentElement.getAttribute('data-mode') === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-mode', next);
+      localStorage.setItem('ui-mode', next);
+    });
+  </script>
 </body>
 </html>
-    `
+`
 
     const response = new Response(html, {
       headers: { 'content-type': 'text/html' },
     })
 
-    return addCSPHeaders(response, env, null, styleNonce)
+    return addCSPHeaders(response, env, [scriptNonce, initNonce], styleNonce)
   }
 
   const now = Math.round(Date.now() / 1000)

--- a/src/handlers/web.ts
+++ b/src/handlers/web.ts
@@ -30,16 +30,12 @@ interface UpdateTrainingResponse {
 
 /**
  * Get all users from the database
- *
- * @param env - Environment bindings
- * @returns List of users with their training status
  */
 async function getAllUsers(env: Env): Promise<User[]> {
   try {
     const result = await env.DB.prepare(
       'SELECT id, username, first_name, primary_email, training_status, created_at, updated_at FROM users ORDER BY username',
     ).all<User>()
-
     return result.results || []
   } catch (error) {
     console.error('Database error:', error)
@@ -47,1350 +43,773 @@ async function getAllUsers(env: Env): Promise<User[]> {
   }
 }
 
-/**
- * Handle GET request for the web interface
- *
- * @param env - Environment bindings
- * @returns HTML response
- */
-export async function handleWebInterface(env: Env): Promise<Response> {
-  // Fetch users from database (no caching - data changes frequently)
-  const users = await getAllUsers(env)
+// ---------------------------------------------------------------------------
+// Shared Kumo-inspired CSS design tokens — light + dark
+// All colors referenced via CSS custom properties so dark mode is a single
+// [data-mode="dark"] block that overrides the :root defaults.
+// ---------------------------------------------------------------------------
+const KUMO_TOKENS = `
+  :root {
+    /* Surfaces */
+    --kumo-canvas:    #f6f8fa;
+    --kumo-base:      #ffffff;
+    --kumo-tint:      #f6f8fa;
+    --kumo-contrast:  #111827;
 
-  // Generate nonces for inline scripts and styles
+    /* Text */
+    --kumo-text-default:  #111827;
+    --kumo-text-strong:   #374151;
+    --kumo-text-subtle:   #6b7280;
+    --kumo-text-inactive: #9ca3af;
+
+    /* Brand */
+    --kumo-orange:        #f38020;
+    --kumo-orange-tint:   #fff4ec;
+    --kumo-orange-border: #fbd5b0;
+
+    /* Status */
+    --kumo-success:        #16a34a;
+    --kumo-success-tint:   #dcfce7;
+    --kumo-success-border: #bbf7d0;
+    --kumo-warning:        #d97706;
+    --kumo-warning-tint:   #fef3c7;
+    --kumo-warning-border: #fde68a;
+    --kumo-danger:         #dc2626;
+    --kumo-danger-tint:    #fee2e2;
+    --kumo-danger-border:  #fecaca;
+    --kumo-info:           #2563eb;
+    --kumo-info-tint:      #dbeafe;
+    --kumo-info-border:    #bfdbfe;
+
+    /* Borders */
+    --kumo-hairline: #e5e7eb;
+    --kumo-border:   #d1d5db;
+
+    /* Shadows */
+    --kumo-shadow-sm: 0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.05);
+    --kumo-shadow-lg: 0 10px 30px rgba(0,0,0,.10), 0 2px 6px rgba(0,0,0,.05);
+
+    /* Radius */
+    --kumo-radius-sm: 6px;
+    --kumo-radius:    8px;
+    --kumo-radius-lg: 12px;
+    --kumo-radius-xl: 16px;
+
+    /* Typography */
+    --kumo-font:      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    --kumo-font-mono: 'SF Mono', Monaco, 'Cascadia Code', 'Fira Code', monospace;
+  }
+
+  /* ── Dark mode overrides ── */
+  [data-mode="dark"] {
+    --kumo-canvas:    #0f1117;
+    --kumo-base:      #1a1d27;
+    --kumo-tint:      #22263a;
+    --kumo-contrast:  #f9fafb;
+
+    --kumo-text-default:  #f3f4f6;
+    --kumo-text-strong:   #d1d5db;
+    --kumo-text-subtle:   #9ca3af;
+    --kumo-text-inactive: #6b7280;
+
+    --kumo-orange-tint:   rgba(243,128,32,.15);
+    --kumo-orange-border: rgba(243,128,32,.35);
+
+    --kumo-success-tint:   rgba(22,163,74,.15);
+    --kumo-success-border: rgba(22,163,74,.35);
+    --kumo-warning-tint:   rgba(217,119,6,.15);
+    --kumo-warning-border: rgba(217,119,6,.35);
+    --kumo-danger-tint:    rgba(220,38,38,.15);
+    --kumo-danger-border:  rgba(220,38,38,.35);
+    --kumo-info-tint:      rgba(37,99,235,.15);
+    --kumo-info-border:    rgba(37,99,235,.35);
+
+    --kumo-hairline: rgba(255,255,255,.08);
+    --kumo-border:   rgba(255,255,255,.14);
+
+    --kumo-shadow-sm: 0 1px 3px rgba(0,0,0,.4), 0 1px 2px rgba(0,0,0,.3);
+    --kumo-shadow-lg: 0 10px 30px rgba(0,0,0,.5), 0 2px 6px rgba(0,0,0,.3);
+  }
+`
+
+// ---------------------------------------------------------------------------
+// Shared theme toggle — flash-prevention init script + toggle button CSS/JS.
+// Inlined as a raw string so each page can embed it with its own nonce.
+// The NONCE placeholder is replaced at render time.
+// ---------------------------------------------------------------------------
+const THEME_INIT_SCRIPT = (nonce: string) => `
+<script nonce="${nonce}">
+  (function() {
+    var stored = localStorage.getItem('ui-mode');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-mode', stored || (prefersDark ? 'dark' : 'light'));
+  })();
+</script>`
+
+const THEME_TOGGLE_CSS = `
+  /* ── Theme toggle button ── */
+  .theme-toggle {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: var(--kumo-radius);
+    border: 1px solid var(--kumo-border);
+    background: var(--kumo-base);
+    color: var(--kumo-text-subtle);
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+    flex-shrink: 0;
+  }
+  .theme-toggle:hover {
+    background: var(--kumo-tint);
+    color: var(--kumo-text-default);
+    border-color: var(--kumo-text-subtle);
+  }
+  .theme-toggle svg { pointer-events: none; }
+  /* Show the right icon based on current mode */
+  .icon-sun  { display: none; }
+  .icon-moon { display: block; }
+  [data-mode="dark"] .icon-sun  { display: block; }
+  [data-mode="dark"] .icon-moon { display: none; }
+`
+
+const THEME_TOGGLE_BTN = `
+  <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark/light mode" title="Toggle dark/light mode">
+    <!-- Sun icon (shown in dark mode to switch to light) -->
+    <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+      <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+    </svg>
+    <!-- Moon icon (shown in light mode to switch to dark) -->
+    <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+  </button>`
+
+const THEME_TOGGLE_JS = `
+    // ── Theme toggle ─────────────────────────────────────────────────────────
+    document.getElementById('themeToggle').addEventListener('click', function() {
+      var next = document.documentElement.getAttribute('data-mode') === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-mode', next);
+      localStorage.setItem('ui-mode', next);
+    });`
+
+// ---------------------------------------------------------------------------
+// Admin Dashboard
+// ---------------------------------------------------------------------------
+
+export async function handleWebInterface(env: Env): Promise<Response> {
+  const users = await getAllUsers(env)
   const styleNonce = generateNonce()
   const scriptNonce = generateNonce()
+  const initNonce = generateNonce()
 
   const html = `
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Training Completion Status</title>
-    <style nonce="${styleNonce}">
-        /* Professional Design System - Gateway Style */
-        :root {
-            --accent: #F38020;         /* Cloudflare Orange */
-            --cta: #2563EB;            /* Blue CTA */
-            --cta-hover: #1E40AF;
-            --surface: #ffffff;        /* Card & modal surface */
-            --muted: #6B7280;          /* Muted text */
-            --border: #E5E7EB;         /* Subtle borders */
-            --panel: #F8FAFC;          /* Light panels inside card */
-            --shadow: 0 12px 30px rgba(2,6,23,.18);
-            --shadow-sm: 0 4px 12px rgba(2,6,23,.08);
-            --radius: 16px;
-            --text-primary: #111827;
-            --text-secondary: #374151;
-
-            /* Status Colors */
-            --status-success: #16A34A;
-            --status-warning: #F59E0B;
-            --status-danger: #DC2626;
-            --status-info: #0EA5E9;
-
-            /* Table Colors */
-            --table-header: #1f2a5a;
-            --table-header-end: #232e65;
-        }
-
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            background: radial-gradient(1200px 800px at 50% -10%, #111827 0%, #0f172a 60%);
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--text-primary);
-            line-height: 1.6;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-            padding: 24px;
-        }
-
-        .container {
-            background: var(--surface);
-            border-radius: var(--radius);
-            box-shadow: var(--shadow);
-            max-width: 1152px;
-            width: 100%;
-            margin: 0;
-            overflow: hidden;
-        }
-
-        .header {
-            background: var(--accent);
-            color: #fff;
-            padding: 28px 28px 24px;
-            text-align: center;
-        }
-
-        .header .icon {
-            font-size: 40px;
-            display: block;
-            margin-bottom: 12px;
-            line-height: 1;
-        }
-
-        .header h1 {
-            font-size: 28px;
-            font-weight: 700;
-            letter-spacing: 0.2px;
-            margin-bottom: 6px;
-        }
-
-        .header p {
-            font-size: 14px;
-            opacity: 0.95;
-        }
-
-        .content {
-            padding: 28px;
-        }
-
-        .controls {
-            background: var(--panel);
-            border: 1px solid var(--border);
-            border-radius: 12px;
-            padding: 18px;
-            margin-bottom: 18px;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 16px;
-        }
-
-
-        .sync-button {
-            appearance: none;
-            border: none;
-            cursor: pointer;
-            background: linear-gradient(180deg, var(--table-header), var(--table-header-end));
-            color: #fff;
-            font-weight: 600;
-            font-size: 16px;
-            padding: 12px 22px;
-            border-radius: 12px;
-            transition: transform 0.05s ease, background 0.2s ease, box-shadow 0.2s ease;
-            box-shadow: 0 6px 14px rgba(31,42,90,.25);
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-        }
-
-        .sync-button:hover {
-            background: linear-gradient(180deg, #253463, #2a3a6f);
-        }
-
-        .sync-button:active {
-            transform: translateY(1px);
-        }
-
-        .sync-button:disabled {
-            opacity: 0.6;
-            cursor: not-allowed;
-        }
-
-        .sync-status {
-            font-weight: 600;
-            color: var(--text-secondary);
-            font-size: 14px;
-        }
-
-        .stats {
-            display: grid;
-            grid-template-columns: repeat(4, minmax(0, 1fr));
-            gap: 16px;
-            margin: 18px 0 24px;
-        }
-
-        .stat-card {
-            background: rgba(255, 255, 255, 0.65);
-            border: 1px solid rgba(15, 23, 42, 0.06);
-            border-radius: 16px;
-            padding: 18px;
-            text-align: center;
-            box-shadow: 0 6px 20px rgba(2, 6, 23, 0.10);
-            transition: transform 0.15s ease;
-        }
-
-        .stat-card:hover {
-            transform: translateY(-2px);
-        }
-
-        .stat-number {
-            font-size: 1.875rem;
-            font-weight: 800;
-            line-height: 1.2;
-        }
-
-        .stat-card.completed .stat-number {
-            color: #10b981;
-        }
-
-        .stat-card.started .stat-number {
-            color: #f59e0b;
-        }
-
-        .stat-card.not-started .stat-number {
-            color: #ef4444;
-        }
-
-        .stat-card.total .stat-number {
-            color: var(--table-header);
-        }
-
-        .stat-label {
-            color: #6B7280;
-            margin-top: 8px;
-            font-weight: 500;
-            font-size: 14px;
-        }
-
-        .table-container {
-            border-radius: 16px;
-            overflow: hidden;
-            background: rgba(255, 255, 255, 0.8);
-            border: 1px solid rgba(15, 23, 42, 0.08);
-            box-shadow: 0 6px 20px rgba(2, 6, 23, 0.10);
-        }
-
-        table {
-            width: 100%;
-            border-collapse: separate;
-            border-spacing: 0;
-        }
-
-        th {
-            background: linear-gradient(180deg, #1f2a5a, #232e65);
-            color: white;
-            font-size: 0.75rem;
-            letter-spacing: 0.06em;
-            text-transform: uppercase;
-            padding: 14px 16px;
-            position: sticky;
-            top: 0;
-            z-index: 1;
-            text-align: left;
-            font-weight: 600;
-        }
-
-        th.sortable {
-            cursor: pointer;
-            user-select: none;
-            padding-right: 32px;
-            transition: background-color 0.2s;
-            position: relative;
-        }
-
-        th.sortable:hover {
-            background: #2a3a6f;
-        }
-
-        th.sortable::after {
-            content: '↕';
-            position: absolute;
-            right: 12px;
-            opacity: 0.5;
-            font-size: 10px;
-        }
-
-        th.sortable.asc::after {
-            content: '↑';
-            opacity: 1;
-        }
-
-        th.sortable.desc::after {
-            content: '↓';
-            opacity: 1;
-        }
-
-        td {
-            padding: 14px 16px;
-            border-top: 1px solid #eef2f7;
-            vertical-align: middle;
-        }
-
-        tr:hover {
-            background: #f8fafc;
-        }
-
-        tr:last-child td {
-            border-bottom: none;
-        }
-
-        .status-select {
-            background: #F8FAFC;
-            border: 2px solid #E5E7EB;
-            border-radius: 8px;
-            padding: 8px 12px;
-            font-size: 13px;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            cursor: pointer;
-            transition: all 0.2s;
-            font-weight: 500;
-            min-width: 140px;
-        }
-
-        .status-select:focus {
-            outline: 2px solid var(--cta);
-            outline-offset: 2px;
-            border-color: var(--cta);
-        }
-
-        .status-completed {
-            background-color: #DCFCE7;
-            color: #166534;
-            border-color: #BBF7D0;
-        }
-
-        .status-started {
-            background-color: #FEF3C7;
-            color: #92400E;
-            border-color: #FDE68A;
-        }
-
-        .status-not-started {
-            background-color: #FEE2E2;
-            color: #991B1B;
-            border-color: #FECACA;
-        }
-
-        .username {
-            font-weight: 600;
-            color: #111827;
-            font-size: 16px;
-        }
-
-        .email {
-            color: #6B7280;
-            font-size: 14px;
-            font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
-        }
-
-        .timestamp {
-            color: #9CA3AF;
-            font-size: 12px;
-            font-weight: 400;
-        }
-
-        .loading {
-            opacity: 0.6;
-            pointer-events: none;
-            position: relative;
-        }
-
-        .loading::after {
-            content: '';
-            position: absolute;
-            inset: 0;
-            background: #F8FAFC;
-            opacity: 0.5;
-            border-radius: 8px;
-        }
-
-        /* Spinner Animation */
-        .spinner {
-            display: inline-block;
-            width: 16px;
-            height: 16px;
-            border: 2px solid #E5E7EB;
-            border-radius: 50%;
-            border-top-color: var(--cta);
-            animation: spin 1s ease-in-out infinite;
-            margin-right: 8px;
-        }
-
-        @keyframes spin {
-            to {
-                transform: rotate(360deg);
-            }
-        }
-
-        .sync-button.loading {
-            pointer-events: none;
-            opacity: 0.8;
-        }
-
-        .sync-button.loading .spinner {
-            border-top-color: #ffffff;
-            border-color: rgba(255, 255, 255, 0.3);
-        }
-
-        .success-message {
-            background: #DCFCE7;
-            color: #166534;
-            padding: 12px 20px;
-            border-radius: 8px;
-            margin: 12px 0;
-            display: none;
-            border-left: 4px solid #16A34A;
-            font-weight: 500;
-            font-size: 14px;
-        }
-
-        .error-message {
-            background: #FEE2E2;
-            color: #991B1B;
-            padding: 12px 20px;
-            border-radius: 8px;
-            margin: 12px 0;
-            display: none;
-            border-left: 4px solid #DC2626;
-            font-weight: 500;
-            font-size: 14px;
-        }
-
-        .access-indicator {
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-            padding: 4px 12px;
-            border-radius: 16px;
-            font-size: 12px;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
-
-        .access-granted {
-            background-color: #DCFCE7;
-            color: #166534;
-            border: 1px solid #BBF7D0;
-        }
-
-        .access-denied {
-            background-color: #FEE2E2;
-            color: #991B1B;
-            border: 1px solid #FECACA;
-        }
-
-        /* Table Filter Controls */
-        .table-filters {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 14px 18px;
-            align-items: end;
-            padding: clamp(16px, 2vw, 24px);
-            background: rgba(255, 255, 255, 0.7);
-            border: 1px solid rgba(15, 23, 42, 0.06);
-            border-radius: 14px;
-            margin-bottom: 18px;
-        }
-
-        .filter-group {
-            display: flex;
-            flex-direction: column;
-            gap: 8px;
-        }
-
-        .filter-label {
-            font-size: 14px;
-            font-weight: 500;
-            color: #374151;
-        }
-
-        .filter-select,
-        .filter-input {
-            padding: 8px 12px;
-            border: 2px solid #E5E7EB;
-            border-radius: 8px;
-            font-size: 14px;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            background: #F8FAFC;
-            transition: all 0.2s;
-            min-width: 160px;
-        }
-
-        .filter-select:focus,
-        .filter-input:focus {
-            outline: 2px solid var(--cta);
-            outline-offset: 2px;
-            border-color: var(--cta);
-        }
-
-        .filter-input::placeholder {
-            color: #9CA3AF;
-        }
-
-        .filter-clear {
-            background: var(--muted);
-            color: white;
-            border: none;
-            padding: 8px 12px;
-            border-radius: 8px;
-            font-size: 14px;
-            cursor: pointer;
-            font-weight: 500;
-        }
-
-        .filter-clear:hover {
-            background: #4B5563;
-        }
-
-        .filter-clear:focus {
-            outline: 2px solid var(--cta);
-            outline-offset: 2px;
-        }
-
-        .filter-count {
-            font-size: 14px;
-            color: #6B7280;
-            font-weight: 500;
-            align-self: center;
-            background: #DBEAFE;
-            padding: 8px 12px;
-            border-radius: 8px;
-            border: 1px solid #BFDBFE;
-        }
-
-        /* Bulk Actions Toolbar */
-        .bulk-actions {
-            display: none;
-            background: #111827;
-            color: #F8FAFC;
-            padding: 16px 20px;
-            border-radius: 8px;
-            margin-bottom: 20px;
-            align-items: center;
-            justify-content: space-between;
-            box-shadow: 0 10px 25px rgba(0,0,0,0.1);
-        }
-
-        .bulk-actions.active {
-            display: flex;
-        }
-
-        .bulk-actions-left {
-            display: flex;
-            align-items: center;
-            gap: 16px;
-        }
-
-        .bulk-selection-count {
-            font-weight: 600;
-            font-size: 16px;
-        }
-
-        .bulk-actions-right {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-        }
-
-        .bulk-action-btn {
-            background: #374151;
-            color: #F8FAFC;
-            border: 1px solid #4B5563;
-            padding: 8px 16px;
-            border-radius: 8px;
-            font-size: 14px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.2s;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-        }
-
-        .bulk-action-btn:hover {
-            background: #4B5563;
-            border-color: #6B7280;
-        }
-
-        .bulk-action-btn:disabled {
-            opacity: 0.5;
-            cursor: not-allowed;
-        }
-
-        .bulk-cancel {
-            background: transparent;
-            color: #D1D5DB;
-            border: 1px solid #4B5563;
-        }
-
-        .bulk-cancel:hover {
-            background: #1F2937;
-            border-color: #6B7280;
-            color: #F8FAFC;
-        }
-
-        /* Checkbox Styling */
-        .checkbox-cell {
-            width: 40px;
-            text-align: center;
-        }
-
-        .user-checkbox,
-        .select-all-checkbox {
-            width: 18px;
-            height: 18px;
-            accent-color: var(--cta);
-            cursor: pointer;
-            border-radius: 4px;
-        }
-
-        .user-checkbox:focus,
-        .select-all-checkbox:focus {
-            outline: 2px solid var(--cta);
-            outline-offset: 2px;
-        }
-
-        tr.selected {
-            background: #DBEAFE;
-        }
-
-        tr.selected:hover {
-            background: #BFDBFE;
-        }
-
-
-        @media (max-width: 768px) {
-            body {
-                padding: 12px;
-            }
-
-            .header {
-                padding: 24px;
-            }
-
-            .header h1 {
-                font-size: 24px;
-            }
-
-            .content {
-                padding: 20px;
-            }
-
-            .controls {
-                flex-direction: column;
-                align-items: stretch;
-                gap: 16px;
-            }
-
-            .sync-status {
-                text-align: center;
-            }
-
-            table {
-                font-size: 14px;
-            }
-
-            th, td {
-                padding: 12px;
-            }
-
-            .stats {
-                grid-template-columns: repeat(2, 1fr);
-                gap: 12px;
-            }
-
-            .table-container {
-                overflow-x: auto;
-            }
-
-            .table-filters {
-                flex-direction: column;
-                align-items: stretch;
-                gap: 16px;
-            }
-
-            .filter-select,
-            .filter-input {
-                min-width: auto;
-            }
-
-            .bulk-actions {
-                flex-direction: column;
-                gap: 16px;
-                text-align: center;
-            }
-
-            .bulk-actions-right {
-                flex-direction: column;
-                gap: 12px;
-            }
-
-            .bulk-action-btn,
-            #bulkStatusSelect {
-                width: 100%;
-            }
-        }
-
-        @media (max-width: 520px) {
-            .stats {
-                grid-template-columns: 1fr;
-            }
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Training Completion Status</title>
+  ${THEME_INIT_SCRIPT(initNonce)}
+  <style nonce="${styleNonce}">
+    ${KUMO_TOKENS}
+
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: var(--kumo-font);
+      background: var(--kumo-canvas);
+      min-height: 100vh;
+      color: var(--kumo-text-default);
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+      transition: background 0.2s, color 0.2s;
+    }
+
+    /* ── Page header ── */
+    .page-header {
+      background: var(--kumo-base);
+      border-bottom: 1px solid var(--kumo-hairline);
+      padding: 0 24px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      height: 56px;
+    }
+    .page-header-logo { display: flex; align-items: center; gap: 8px; }
+    .cf-dot { width: 20px; height: 20px; background: var(--kumo-orange); border-radius: 50%; flex-shrink: 0; }
+    .page-header-title { font-size: 15px; font-weight: 600; color: var(--kumo-text-default); }
+    .page-header-sep { color: var(--kumo-hairline); font-size: 18px; font-weight: 300; margin: 0 4px; }
+    .page-header-sub { font-size: 14px; color: var(--kumo-text-subtle); }
+
+    ${THEME_TOGGLE_CSS}
+
+    /* ── Page body ── */
+    .page-body { max-width: 1200px; margin: 0 auto; padding: 28px 24px 48px; }
+
+    .section-heading { font-size: 22px; font-weight: 700; color: var(--kumo-text-default); margin-bottom: 4px; }
+    .section-sub { font-size: 14px; color: var(--kumo-text-subtle); margin-bottom: 24px; }
+
+    /* ── Toasts ── */
+    .toast {
+      display: none; align-items: center; gap: 10px;
+      padding: 12px 16px; border-radius: var(--kumo-radius);
+      margin-bottom: 16px; font-size: 14px; font-weight: 500;
+      border-left: 3px solid transparent;
+    }
+    .toast.visible { display: flex; }
+    .toast-success { background: var(--kumo-success-tint); color: var(--kumo-success); border-left-color: var(--kumo-success); }
+    .toast-error   { background: var(--kumo-danger-tint);  color: var(--kumo-danger);  border-left-color: var(--kumo-danger); }
+    .toast-icon { font-size: 16px; flex-shrink: 0; }
+
+    /* ── Toolbar ── */
+    .toolbar {
+      display: flex; align-items: center; justify-content: space-between; gap: 12px;
+      padding: 14px 16px; background: var(--kumo-tint);
+      border: 1px solid var(--kumo-hairline); border-radius: var(--kumo-radius-lg);
+      margin-bottom: 20px;
+    }
+    .toolbar-label { font-size: 14px; color: var(--kumo-text-subtle); }
+
+    /* ── Buttons ── */
+    .btn {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 8px 16px; border-radius: var(--kumo-radius);
+      font-size: 14px; font-weight: 500; font-family: var(--kumo-font);
+      cursor: pointer; border: 1px solid transparent;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+      white-space: nowrap;
+    }
+    .btn:disabled { opacity: 0.55; cursor: not-allowed; }
+    .btn-primary { background: var(--kumo-orange); color: #fff; border-color: var(--kumo-orange); }
+    .btn-primary:hover:not(:disabled) { background: #d96e18; border-color: #d96e18; }
+    .btn-ghost { background: transparent; color: var(--kumo-text-subtle); border-color: transparent; }
+    .btn-ghost:hover:not(:disabled) { background: var(--kumo-tint); color: var(--kumo-text-default); }
+
+    /* ── Stats ── */
+    .stats-grid {
+      display: grid; grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px; margin-bottom: 20px;
+    }
+    .stat-card {
+      background: var(--kumo-base); border: 1px solid var(--kumo-hairline);
+      border-radius: var(--kumo-radius-lg); padding: 18px 20px;
+      display: flex; flex-direction: column; gap: 4px;
+      box-shadow: var(--kumo-shadow-sm);
+    }
+    .stat-value { font-size: 28px; font-weight: 800; line-height: 1.1; }
+    .stat-label { font-size: 13px; color: var(--kumo-text-subtle); font-weight: 500; }
+    .stat-card.completed  .stat-value { color: var(--kumo-success); }
+    .stat-card.started    .stat-value { color: var(--kumo-warning); }
+    .stat-card.not-started .stat-value { color: var(--kumo-danger); }
+    .stat-card.total       .stat-value { color: var(--kumo-text-default); }
+
+    /* ── Filters ── */
+    .filters-row {
+      display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end;
+      padding: 14px 16px; background: var(--kumo-tint);
+      border: 1px solid var(--kumo-hairline); border-radius: var(--kumo-radius-lg);
+      margin-bottom: 14px;
+    }
+    .filter-group { display: flex; flex-direction: column; gap: 5px; }
+    .filter-label { font-size: 12px; font-weight: 500; color: var(--kumo-text-subtle); text-transform: uppercase; letter-spacing: 0.04em; }
+    .filter-input, .filter-select {
+      padding: 7px 10px; border: 1px solid var(--kumo-border);
+      border-radius: var(--kumo-radius); font-size: 14px; font-family: var(--kumo-font);
+      background: var(--kumo-base); color: var(--kumo-text-default);
+      min-width: 160px; transition: border-color 0.15s, box-shadow 0.15s;
+    }
+    .filter-input:focus, .filter-select:focus {
+      outline: none; border-color: var(--kumo-orange);
+      box-shadow: 0 0 0 3px var(--kumo-orange-tint);
+    }
+    .filter-input::placeholder { color: var(--kumo-text-inactive); }
+    .filter-count {
+      display: none; font-size: 13px; color: var(--kumo-text-subtle);
+      background: var(--kumo-info-tint); border: 1px solid var(--kumo-info-border);
+      border-radius: var(--kumo-radius); padding: 7px 12px; align-self: flex-end;
+    }
+
+    /* ── Bulk bar ── */
+    .bulk-bar {
+      display: none; align-items: center; justify-content: space-between; gap: 12px;
+      padding: 12px 16px; background: var(--kumo-contrast); color: var(--kumo-canvas);
+      border-radius: var(--kumo-radius-lg); margin-bottom: 14px;
+    }
+    .bulk-bar.active { display: flex; }
+    .bulk-bar-left  { display: flex; align-items: center; gap: 12px; }
+    .bulk-bar-right { display: flex; align-items: center; gap: 10px; }
+    .bulk-count { font-size: 14px; font-weight: 600; }
+    .bulk-select {
+      padding: 7px 10px; border-radius: var(--kumo-radius); font-size: 14px;
+      font-family: var(--kumo-font); background: rgba(255,255,255,.1);
+      color: inherit; border: 1px solid rgba(255,255,255,.2); cursor: pointer;
+    }
+    .bulk-select:focus { outline: none; border-color: var(--kumo-orange); }
+    .btn-bulk {
+      padding: 7px 14px; border-radius: var(--kumo-radius); font-size: 14px;
+      font-weight: 500; font-family: var(--kumo-font); cursor: pointer;
+      border: 1px solid rgba(255,255,255,.2); background: rgba(255,255,255,.1);
+      color: inherit; transition: background 0.15s;
+    }
+    .btn-bulk:hover:not(:disabled) { background: rgba(255,255,255,.2); }
+    .btn-bulk:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-bulk-cancel { background: transparent; }
+    .btn-bulk-cancel:hover:not(:disabled) { background: rgba(255,255,255,.08); }
+
+    /* ── Table ── */
+    .table-wrap {
+      border: 1px solid var(--kumo-hairline); border-radius: var(--kumo-radius-lg);
+      overflow: hidden; box-shadow: var(--kumo-shadow-sm);
+    }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    thead tr { background: var(--kumo-tint); border-bottom: 1px solid var(--kumo-hairline); }
+    th {
+      padding: 10px 14px; font-size: 11px; font-weight: 600;
+      color: var(--kumo-text-subtle); text-transform: uppercase;
+      letter-spacing: 0.06em; text-align: left; white-space: nowrap;
+    }
+    th.sortable { cursor: pointer; user-select: none; padding-right: 28px; position: relative; transition: color 0.15s; }
+    th.sortable:hover { color: var(--kumo-text-default); }
+    th.sortable::after { content: '↕'; position: absolute; right: 10px; opacity: 0.35; font-size: 10px; }
+    th.sortable.asc::after  { content: '↑'; opacity: 0.9; color: var(--kumo-orange); }
+    th.sortable.desc::after { content: '↓'; opacity: 0.9; color: var(--kumo-orange); }
+    .checkbox-cell { width: 40px; padding: 10px 14px; text-align: center; }
+    td {
+      padding: 12px 14px; border-bottom: 1px solid var(--kumo-hairline);
+      vertical-align: middle; background: var(--kumo-base);
+      transition: background 0.1s;
+    }
+    tbody tr:last-child td { border-bottom: none; }
+    tbody tr:hover td { background: var(--kumo-tint); }
+    tbody tr.selected td { background: var(--kumo-info-tint); }
+    .user-name  { font-weight: 600; color: var(--kumo-text-default); }
+    .user-email { font-size: 13px; color: var(--kumo-text-subtle); font-family: var(--kumo-font-mono); }
+    .timestamp  { font-size: 12px; color: var(--kumo-text-inactive); }
+    .user-checkbox, .select-all-checkbox { width: 16px; height: 16px; accent-color: var(--kumo-orange); cursor: pointer; }
+
+    /* ── Status select ── */
+    .status-select {
+      padding: 5px 10px; border-radius: 20px; font-size: 12px; font-weight: 600;
+      font-family: var(--kumo-font); border: 1px solid; cursor: pointer;
+      appearance: none; background-repeat: no-repeat;
+      background-position: right 8px center; background-size: 10px; padding-right: 24px;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%236b7280'/%3E%3C/svg%3E");
+      transition: box-shadow 0.15s;
+    }
+    .status-select:focus { outline: none; box-shadow: 0 0 0 3px var(--kumo-orange-tint); }
+    .status-select.status-completed  { background-color: var(--kumo-success-tint); color: var(--kumo-success); border-color: var(--kumo-success-border); }
+    .status-select.status-started    { background-color: var(--kumo-warning-tint); color: var(--kumo-warning); border-color: var(--kumo-warning-border); }
+    .status-select.status-not-started { background-color: var(--kumo-danger-tint);  color: var(--kumo-danger);  border-color: var(--kumo-danger-border); }
+
+    /* ── Badge ── */
+    .badge {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 3px 10px; border-radius: 20px; font-size: 11px;
+      font-weight: 600; letter-spacing: 0.03em; border: 1px solid; white-space: nowrap;
+    }
+    .badge-success { background: var(--kumo-success-tint); color: var(--kumo-success); border-color: var(--kumo-success-border); }
+    .badge-danger  { background: var(--kumo-danger-tint);  color: var(--kumo-danger);  border-color: var(--kumo-danger-border); }
+    .badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
+
+    /* ── Spinner ── */
+    .spinner {
+      display: inline-block; width: 14px; height: 14px;
+      border: 2px solid rgba(255,255,255,0.35); border-top-color: #fff;
+      border-radius: 50%; animation: spin 0.7s linear infinite; flex-shrink: 0;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ── Responsive ── */
+    @media (max-width: 768px) {
+      .page-body { padding: 20px 16px 40px; }
+      .stats-grid { grid-template-columns: repeat(2, 1fr); }
+      .toolbar { flex-direction: column; align-items: stretch; }
+      .bulk-bar { flex-direction: column; }
+      .bulk-bar-right { flex-wrap: wrap; }
+      .table-wrap { overflow-x: auto; }
+    }
+    @media (max-width: 480px) {
+      .stats-grid { grid-template-columns: 1fr; }
+      .filters-row { flex-direction: column; align-items: stretch; }
+      .filter-input, .filter-select { min-width: 0; }
+    }
+  </style>
 </head>
 <body>
-    <div class="container">
-        <div class="header">
-            <span class="icon">🎓</span>
-            <h1>Training Completion Status for the Team</h1>
-            <p>Manage and track training certification progress</p>
-        </div>
 
-        <div class="content">
-            <div class="success-message" id="successMessage">Training status updated successfully!</div>
-            <div class="error-message" id="errorMessage">Failed to update training status. Please try again.</div>
+  <header class="page-header">
+    <div class="page-header-logo">
+      <div class="cf-dot"></div>
+      <span class="page-header-title">Cloudflare Access</span>
+    </div>
+    <span class="page-header-sep">|</span>
+    <span class="page-header-sub">Training Completion Status</span>
+    ${THEME_TOGGLE_BTN}
+  </header>
 
-            <div class="controls">
-                <div class="sync-status">
-                    <span id="syncStatus">Ready to sync users from Okta</span>
-                </div>
-                <button class="sync-button" id="syncButton">
-                    🔄 Sync Users from Okta
-                </button>
-            </div>
+  <div class="page-body">
+    <h1 class="section-heading">Training Dashboard</h1>
+    <p class="section-sub">Manage and track training certification progress across the team.</p>
 
-
-            <div class="stats">
-                <div class="stat-card completed">
-                    <div class="stat-number" id="completedCount">${users.filter((u) => u.training_status === 'completed').length}</div>
-                    <div class="stat-label">Completed</div>
-                </div>
-                <div class="stat-card started">
-                    <div class="stat-number" id="startedCount">${users.filter((u) => u.training_status === 'started').length}</div>
-                    <div class="stat-label">In Progress</div>
-                </div>
-                <div class="stat-card not-started">
-                    <div class="stat-number" id="notStartedCount">${users.filter((u) => u.training_status === 'not started').length}</div>
-                    <div class="stat-label">Not Started</div>
-                </div>
-                <div class="stat-card total">
-                    <div class="stat-number" id="totalCount">${users.length}</div>
-                    <div class="stat-label">Total Users</div>
-                </div>
-            </div>
-                    <div class="table-filters">
-                <div class="filter-group">
-                    <label for="statusFilter" class="filter-label">Filter by Status:</label>
-                    <select id="statusFilter" class="filter-select">
-                        <option value="">All Status</option>
-                        <option value="completed">Completed</option>
-                        <option value="started">In Progress</option>
-                        <option value="not started">Not Started</option>
-                    </select>
-                </div>
-                <div class="filter-group">
-                    <label for="searchFilter" class="filter-label">Search:</label>
-                    <input type="text" id="searchFilter" class="filter-input" placeholder="Search by name or email...">
-                </div>
-                <div class="filter-group">
-                    <label class="filter-label" style="visibility: hidden;">Actions:</label>
-                    <button type="button" class="filter-clear" id="clearFiltersBtn">Clear Filters</button>
-                </div>
-            </div>
-
-            <div class="bulk-actions" id="bulkActionsToolbar">
-                <div class="bulk-actions-left">
-                    <span class="bulk-selection-count" id="bulkSelectionCount">0 users selected</span>
-                </div>
-                <div class="bulk-actions-right">
-                    <select id="bulkStatusSelect" class="bulk-action-btn" style="background: #374151; color: #F8FAFC;">
-                        <option value="">Change Status To...</option>
-                        <option value="completed">Mark as Completed</option>
-                        <option value="started">Mark as In Progress</option>
-                        <option value="not started">Mark as Not Started</option>
-                    </select>
-                    <button type="button" class="bulk-action-btn" id="applyBulkAction">Apply</button>
-                    <button type="button" class="bulk-action-btn bulk-cancel" id="cancelBulkAction">Cancel</button>
-                </div>
-            </div>
-
-            <div class="table-container">
-                <table id="usersTable">
-                    <thead>
-                        <tr>
-                            <th class="checkbox-cell">
-                                <input type="checkbox" class="select-all-checkbox" id="selectAllCheckbox">
-                            </th>
-                            <th class="sortable" data-column="first_name">First Name</th>
-                            <th class="sortable" data-column="primary_email">Primary Email</th>
-                            <th class="sortable" data-column="training_status">Training Status</th>
-                            <th>Access Status</th>
-                            <th class="sortable" data-column="updated_at">Last Updated</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        ${users
-                          .map(
-                            (user) => `
-                            <tr data-user-id="${user.id}" data-user-email="${user.primary_email}">
-                                <td class="checkbox-cell">
-                                    <input type="checkbox" class="user-checkbox" value="${user.primary_email}">
-                                </td>
-                                <td class="username">${user.first_name || '-'}</td>
-                                <td class="email">${user.primary_email || '-'}</td>
-                                <td>
-                                    <select class="status-select status-${user.training_status.replace(' ', '-')}"
-                                            data-email="${user.primary_email}"
-                                            data-original-value="${user.training_status}">
-                                        <option value="not started" ${user.training_status === 'not started' ? 'selected' : ''}>Not Started</option>
-                                        <option value="started" ${user.training_status === 'started' ? 'selected' : ''}>In Progress</option>
-                                        <option value="completed" ${user.training_status === 'completed' ? 'selected' : ''}>Completed</option>
-                                    </select>
-                                </td>
-                                <td>
-                                    <span class="access-indicator ${user.training_status === 'completed' ? 'access-granted' : 'access-denied'}">
-                                        ${user.training_status === 'completed' ? '✅ Access Granted' : '❌ Access Denied'}
-                                    </span>
-                                </td>
-                                <td class="timestamp">${new Date(user.updated_at).toLocaleString()}</td>
-                            </tr>
-                        `,
-                          )
-                          .join('')}
-                    </tbody>
-                    </table>
-                </div>
-        </div>
+    <div class="toast toast-success" id="successToast">
+      <span class="toast-icon">✓</span>
+      <span id="successText">Training status updated successfully.</span>
+    </div>
+    <div class="toast toast-error" id="errorToast">
+      <span class="toast-icon">✕</span>
+      <span id="errorText">Failed to update training status.</span>
     </div>
 
-    <script nonce="${scriptNonce}">
-        async function updateTrainingStatus(email, newStatus, selectElement) {
-            const originalValue = selectElement.getAttribute('data-original-value');
-
-            if (newStatus === originalValue) {
-                return; // No change
-            }
-
-            // Add loading state
-            selectElement.classList.add('loading');
-
-            try {
-                const response = await fetch('/api/update-training', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    credentials: 'same-origin',
-                    body: JSON.stringify({
-                        email: email,
-                        status: newStatus
-                    })
-                });
-
-                const result = await response.json();
-
-                if (result.success) {
-                    // Update the select styling
-                    selectElement.className = 'status-select status-' + newStatus.replace(' ', '-');
-                    selectElement.setAttribute('data-original-value', newStatus);
-
-                    // Update timestamp
-                    const row = selectElement.closest('tr');
-                    const timestampCell = row.querySelector('.timestamp');
-                    timestampCell.textContent = new Date().toLocaleString();
-
-                    // Update access status
-                    const accessCell = row.querySelector('.access-indicator');
-                    if (newStatus === 'completed') {
-                        accessCell.className = 'access-indicator access-granted';
-                        accessCell.textContent = '✅ Access Granted';
-                    } else {
-                        accessCell.className = 'access-indicator access-denied';
-                        accessCell.textContent = '❌ Access Denied';
-                    }
-
-                    // Update stats
-                    updateStats();
-
-                    // Show success message
-                    showMessage('success', 'Training status updated successfully!');
-                } else {
-                    // Revert selection
-                    selectElement.value = originalValue;
-                    showMessage('error', result.message || 'Failed to update training status');
-                }
-            } catch (error) {
-                console.error('Error updating training status:', error);
-                // Revert selection
-                selectElement.value = originalValue;
-                showMessage('error', 'Network error. Please try again.');
-            } finally {
-                selectElement.classList.remove('loading');
-            }
-        }
-
-        function updateStats() {
-            const selects = document.querySelectorAll('.status-select');
-            let completed = 0, started = 0, notStarted = 0;
-
-            selects.forEach(select => {
-                const status = select.value;
-                if (status === 'completed') completed++;
-                else if (status === 'started') started++;
-                else if (status === 'not started') notStarted++;
-            });
-
-            document.getElementById('completedCount').textContent = completed;
-            document.getElementById('startedCount').textContent = started;
-            document.getElementById('notStartedCount').textContent = notStarted;
-        }
-
-        async function syncOktaUsers() {
-            const syncButton = document.getElementById('syncButton');
-            const syncStatus = document.getElementById('syncStatus');
-
-            // Disable button and show loading state
-            syncButton.disabled = true;
-            syncButton.classList.add('loading');
-            syncButton.innerHTML = '<span class="spinner"></span>Syncing...';
-            syncStatus.textContent = 'Syncing users from Okta...';
-
-            try {
-                const response = await fetch('/api/okta/sync', {
-                    method: 'POST',
-                    credentials: 'same-origin'
-                });
-
-                const result = await response.json();
-
-                if (result.success) {
-                    syncStatus.textContent = \`Sync completed: Added \${result.results.added}, Updated \${result.results.updated}, Skipped \${result.results.skipped}\`;
-                    showMessage('success', result.message);
-
-                    // Refresh the page to show new users
-                    setTimeout(() => {
-                        window.location.reload();
-                    }, 2000);
-                } else {
-                    syncStatus.textContent = 'Sync failed';
-                    showMessage('error', result.message || 'Failed to sync users from Okta');
-                }
-            } catch (error) {
-                console.error('Sync error:', error);
-                syncStatus.textContent = 'Sync failed';
-                showMessage('error', 'Network error during sync. Please try again.');
-            } finally {
-                // Re-enable button
-                syncButton.disabled = false;
-                syncButton.classList.remove('loading');
-                syncButton.innerHTML = '🔄 Sync Users from Okta';
-
-                // Reset status after delay
-                setTimeout(() => {
-                    syncStatus.textContent = 'Ready to sync users from Okta';
-                }, 5000);
-            }
-        }
-
-        function showMessage(type, message) {
-            const successMsg = document.getElementById('successMessage');
-            const errorMsg = document.getElementById('errorMessage');
-
-            // Hide both messages first
-            successMsg.style.display = 'none';
-            errorMsg.style.display = 'none';
-
-            if (type === 'success') {
-                successMsg.textContent = message;
-                successMsg.style.display = 'block';
-                setTimeout(() => successMsg.style.display = 'none', 3000);
-            } else {
-                errorMsg.textContent = message;
-                errorMsg.style.display = 'block';
-                setTimeout(() => errorMsg.style.display = 'none', 5000);
-            }
-        }
-
-        // Table sorting functionality
-        let currentSort = { column: null, direction: 'asc' };
-
-        function initializeSorting() {
-            const sortableHeaders = document.querySelectorAll('th.sortable');
-            sortableHeaders.forEach(header => {
-                header.addEventListener('click', () => {
-                    const column = header.getAttribute('data-column');
-                    sortTable(column, header);
-                });
-            });
-        }
-
-        function sortTable(column, headerElement) {
-            const table = document.getElementById('usersTable');
-            const tbody = table.querySelector('tbody');
-            const rows = Array.from(tbody.querySelectorAll('tr'));
-
-            // Determine sort direction
-            let direction = 'asc';
-            if (currentSort.column === column && currentSort.direction === 'asc') {
-                direction = 'desc';
-            }
-
-            // Update header classes
-            document.querySelectorAll('th.sortable').forEach(th => {
-                th.classList.remove('asc', 'desc');
-            });
-            headerElement.classList.add(direction);
-
-            // Sort rows
-            rows.sort((a, b) => {
-                let aValue = getCellValue(a, column);
-                let bValue = getCellValue(b, column);
-
-                // Handle different data types
-                if (column === 'updated_at') {
-                    aValue = new Date(aValue);
-                    bValue = new Date(bValue);
-                } else if (column === 'training_status') {
-                    // Custom sort order for training status
-                    const statusOrder = { 'completed': 3, 'started': 2, 'not started': 1 };
-                    aValue = statusOrder[aValue] || 0;
-                    bValue = statusOrder[bValue] || 0;
-                } else {
-                    aValue = aValue.toLowerCase();
-                    bValue = bValue.toLowerCase();
-                }
-
-                if (direction === 'asc') {
-                    return aValue > bValue ? 1 : -1;
-                } else {
-                    return aValue < bValue ? 1 : -1;
-                }
-            });
-
-            // Re-append sorted rows
-            rows.forEach(row => tbody.appendChild(row));
-
-            // Update current sort state
-            currentSort = { column, direction };
-        }
-
-        function getCellValue(row, column) {
-            switch (column) {
-                case 'first_name':
-                    return row.querySelector('.username').textContent.trim();
-                case 'primary_email':
-                    return row.querySelector('.email').textContent.trim();
-                case 'training_status':
-                    return row.querySelector('.status-select').value;
-                case 'updated_at':
-                    return row.querySelector('.timestamp').textContent.trim();
-                default:
-                    return '';
-            }
-        }
-
-        // Table filtering functionality
-        function initializeFiltering() {
-            const statusFilter = document.getElementById('statusFilter');
-            const searchFilter = document.getElementById('searchFilter');
-
-            statusFilter.addEventListener('change', applyFilters);
-            searchFilter.addEventListener('input', debounce(applyFilters, 300));
-        }
-
-        function applyFilters() {
-            const statusFilter = document.getElementById('statusFilter').value;
-            const searchFilter = document.getElementById('searchFilter').value.toLowerCase();
-            const rows = document.querySelectorAll('#usersTable tbody tr');
-
-            let visibleCount = 0;
-
-            rows.forEach(row => {
-                const status = row.querySelector('.status-select').value;
-                const name = row.querySelector('.username').textContent.toLowerCase();
-                const email = row.querySelector('.email').textContent.toLowerCase();
-
-                const statusMatch = !statusFilter || status === statusFilter;
-                const searchMatch = !searchFilter ||
-                    name.includes(searchFilter) ||
-                    email.includes(searchFilter);
-
-                if (statusMatch && searchMatch) {
-                    row.style.display = '';
-                    visibleCount++;
-                } else {
-                    row.style.display = 'none';
-                }
-            });
-
-            // Update visible count indicator
-            updateFilteredCount(visibleCount, rows.length);
-        }
-
-        function clearFilters() {
-            document.getElementById('statusFilter').value = '';
-            document.getElementById('searchFilter').value = '';
-            applyFilters();
-        }
-
-        function updateFilteredCount(visible, total) {
-            // Find or create the filter count indicator
-            let countIndicator = document.querySelector('.filter-count');
-            if (!countIndicator) {
-                countIndicator = document.createElement('div');
-                countIndicator.className = 'filter-count';
-                document.querySelector('.table-filters').appendChild(countIndicator);
-            }
-
-            if (visible === total) {
-                countIndicator.style.display = 'none';
-            } else {
-                countIndicator.style.display = 'block';
-                countIndicator.textContent = 'Showing ' + visible + ' of ' + total + ' users';
-            }
-        }
-
-        function debounce(func, wait) {
-            let timeout;
-            return function executedFunction(...args) {
-                const later = () => {
-                    clearTimeout(timeout);
-                    func(...args);
-                };
-                clearTimeout(timeout);
-                timeout = setTimeout(later, wait);
-            };
-        }
-
-        // Bulk actions functionality
-        let selectedUsers = [];
-
-        function updateSelection() {
-            const checkboxes = document.querySelectorAll('.user-checkbox');
-            selectedUsers = Array.from(checkboxes)
-                .filter(cb => cb.checked)
-                .map(cb => cb.value);
-
-            updateBulkActionsUI();
-        }
-
-        function toggleAllSelection(selectAllCheckbox) {
-            const checkboxes = document.querySelectorAll('.user-checkbox');
-            const visibleCheckboxes = Array.from(checkboxes).filter(cb => {
-                const row = cb.closest('tr');
-                return row && row.style.display !== 'none';
-            });
-
-            visibleCheckboxes.forEach(checkbox => {
-                checkbox.checked = selectAllCheckbox.checked;
-                const row = checkbox.closest('tr');
-                if (checkbox.checked) {
-                    row.classList.add('selected');
-                } else {
-                    row.classList.remove('selected');
-                }
-            });
-
-            updateSelection();
-        }
-
-        function updateBulkActionsUI() {
-            const toolbar = document.getElementById('bulkActionsToolbar');
-            const countDisplay = document.getElementById('bulkSelectionCount');
-            const selectAllCheckbox = document.getElementById('selectAllCheckbox');
-
-            if (selectedUsers.length > 0) {
-                toolbar.classList.add('active');
-                countDisplay.textContent = selectedUsers.length + ' user' + (selectedUsers.length !== 1 ? 's' : '') + ' selected';
-
-                // Update row highlighting
-                document.querySelectorAll('.user-checkbox').forEach(checkbox => {
-                    const row = checkbox.closest('tr');
-                    if (checkbox.checked) {
-                        row.classList.add('selected');
-                    } else {
-                        row.classList.remove('selected');
-                    }
-                });
-            } else {
-                toolbar.classList.remove('active');
-                selectAllCheckbox.checked = false;
-                document.querySelectorAll('tr.selected').forEach(row => {
-                    row.classList.remove('selected');
-                });
-            }
-
-            // Update select all checkbox state
-            const visibleCheckboxes = Array.from(document.querySelectorAll('.user-checkbox')).filter(cb => {
-                const row = cb.closest('tr');
-                return row && row.style.display !== 'none';
-            });
-            const checkedVisibleCheckboxes = visibleCheckboxes.filter(cb => cb.checked);
-
-            if (checkedVisibleCheckboxes.length === 0) {
-                selectAllCheckbox.indeterminate = false;
-                selectAllCheckbox.checked = false;
-            } else if (checkedVisibleCheckboxes.length === visibleCheckboxes.length) {
-                selectAllCheckbox.indeterminate = false;
-                selectAllCheckbox.checked = true;
-            } else {
-                selectAllCheckbox.indeterminate = true;
-                selectAllCheckbox.checked = false;
-            }
-        }
-
-        function clearSelection() {
-            document.querySelectorAll('.user-checkbox').forEach(checkbox => {
-                checkbox.checked = false;
-            });
-            document.getElementById('bulkStatusSelect').value = '';
-            updateSelection();
-        }
-
-        async function applyBulkStatusUpdate() {
-            const newStatus = document.getElementById('bulkStatusSelect').value;
-            if (!newStatus || selectedUsers.length === 0) {
-                showMessage('error', 'Please select a status and at least one user.');
-                return;
-            }
-
-            const applyButton = document.getElementById('applyBulkAction');
-            const originalText = applyButton.textContent;
-            applyButton.disabled = true;
-            applyButton.textContent = 'Updating...';
-
-            try {
-                // Update each user's status
-                const updatePromises = selectedUsers.map(async (email) => {
-                    const response = await fetch('/api/update-training', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        credentials: 'same-origin',
-                        body: JSON.stringify({
-                            email: email,
-                            status: newStatus
-                        })
-                    });
-                    return { email, response: await response.json() };
-                });
-
-                const results = await Promise.all(updatePromises);
-                const successful = results.filter(r => r.response.success);
-                const failed = results.filter(r => !r.response.success);
-
-                if (successful.length > 0) {
-                    // Update the UI for successful updates
-                    successful.forEach(result => {
-                        const row = document.querySelector('tr[data-user-email="' + result.email + '"]');
-                        if (row) {
-                            const select = row.querySelector('.status-select');
-                            const accessIndicator = row.querySelector('.access-indicator');
-
-                            select.value = newStatus;
-                            select.className = 'status-select status-' + newStatus.replace(' ', '-');
-                            select.setAttribute('data-original-value', newStatus);
-
-                            // Update access indicator
-                            if (newStatus === 'completed') {
-                                accessIndicator.className = 'access-indicator access-granted';
-                                accessIndicator.textContent = '✅ Access Granted';
-                            } else {
-                                accessIndicator.className = 'access-indicator access-denied';
-                                accessIndicator.textContent = '❌ Access Denied';
-                            }
-                        }
-                    });
-
-                    // Update statistics
-                    updateStatistics();
-
-                    showMessage('success', 'Successfully updated ' + successful.length + ' user' + (successful.length !== 1 ? 's' : '') + ' to "' + newStatus + '".');
-                }
-
-                if (failed.length > 0) {
-                    showMessage('error', 'Failed to update ' + failed.length + ' user' + (failed.length !== 1 ? 's' : '') + '. Please try again.');
-                }
-
-                // Clear selection after bulk update
-                clearSelection();
-
-            } catch (error) {
-                console.error('Bulk update error:', error);
-                showMessage('error', 'Bulk update failed. Please try again.');
-            } finally {
-                applyButton.disabled = false;
-                applyButton.textContent = originalText;
-            }
-        }
-
-        function updateStatistics() {
-            const rows = document.querySelectorAll('#usersTable tbody tr');
-            let completed = 0, started = 0, notStarted = 0;
-
-            rows.forEach(row => {
-                const status = row.querySelector('.status-select').value;
-                if (status === 'completed') completed++;
-                else if (status === 'started') started++;
-                else if (status === 'not started') notStarted++;
-            });
-
-            document.getElementById('completedCount').textContent = completed;
-            document.getElementById('startedCount').textContent = started;
-            document.getElementById('notStartedCount').textContent = notStarted;
-        }
-
-        // Initialize event listeners for elements
-        function initializeEventListeners() {
-            // Sync button
-            const syncButton = document.getElementById('syncButton');
-            if (syncButton) {
-                syncButton.addEventListener('click', syncOktaUsers);
-            }
-
-            // Clear filters button
-            const clearFiltersBtn = document.getElementById('clearFiltersBtn');
-            if (clearFiltersBtn) {
-                clearFiltersBtn.addEventListener('click', clearFilters);
-            }
-
-            // Bulk action buttons
-            const applyBulkAction = document.getElementById('applyBulkAction');
-            if (applyBulkAction) {
-                applyBulkAction.addEventListener('click', applyBulkStatusUpdate);
-            }
-
-            const cancelBulkAction = document.getElementById('cancelBulkAction');
-            if (cancelBulkAction) {
-                cancelBulkAction.addEventListener('click', clearSelection);
-            }
-
-            // Select all checkbox
-            const selectAllCheckbox = document.getElementById('selectAllCheckbox');
-            if (selectAllCheckbox) {
-                selectAllCheckbox.addEventListener('change', function() {
-                    toggleAllSelection(this);
-                });
-            }
-
-            // User checkboxes (using event delegation on table)
-            const usersTable = document.getElementById('usersTable');
-            if (usersTable) {
-                usersTable.addEventListener('change', function(e) {
-                    if (e.target.classList.contains('user-checkbox')) {
-                        updateSelection();
-                    }
-                    if (e.target.classList.contains('status-select')) {
-                        const email = e.target.getAttribute('data-email');
-                        const newStatus = e.target.value;
-                        updateTrainingStatus(email, newStatus, e.target);
-                    }
-                });
-            }
-        }
-
-        // Initialize sorting and filtering when page loads
-        document.addEventListener('DOMContentLoaded', () => {
-            initializeSorting();
-            initializeFiltering();
-            initializeEventListeners();
+    <div class="toolbar">
+      <span class="toolbar-label" id="syncStatus">Ready to sync users from Okta</span>
+      <button class="btn btn-primary" id="syncButton">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M14 8A6 6 0 1 1 8 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          <path d="M8 0l2.5 2.5L8 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        Sync from Okta
+      </button>
+    </div>
+
+    <div class="stats-grid">
+      <div class="stat-card completed">
+        <span class="stat-value" id="completedCount">${users.filter((u) => u.training_status === 'completed').length}</span>
+        <span class="stat-label">Completed</span>
+      </div>
+      <div class="stat-card started">
+        <span class="stat-value" id="startedCount">${users.filter((u) => u.training_status === 'started').length}</span>
+        <span class="stat-label">In Progress</span>
+      </div>
+      <div class="stat-card not-started">
+        <span class="stat-value" id="notStartedCount">${users.filter((u) => u.training_status === 'not started').length}</span>
+        <span class="stat-label">Not Started</span>
+      </div>
+      <div class="stat-card total">
+        <span class="stat-value" id="totalCount">${users.length}</span>
+        <span class="stat-label">Total Users</span>
+      </div>
+    </div>
+
+    <div class="filters-row">
+      <div class="filter-group">
+        <label for="statusFilter" class="filter-label">Status</label>
+        <select id="statusFilter" class="filter-select">
+          <option value="">All</option>
+          <option value="completed">Completed</option>
+          <option value="started">In Progress</option>
+          <option value="not started">Not Started</option>
+        </select>
+      </div>
+      <div class="filter-group">
+        <label for="searchFilter" class="filter-label">Search</label>
+        <input type="text" id="searchFilter" class="filter-input" placeholder="Name or email…">
+      </div>
+      <div class="filter-group" style="justify-content:flex-end;">
+        <label class="filter-label" style="visibility:hidden">Reset</label>
+        <button type="button" class="btn btn-ghost" id="clearFiltersBtn">Clear filters</button>
+      </div>
+      <div class="filter-count" id="filterCount"></div>
+    </div>
+
+    <div class="bulk-bar" id="bulkBar">
+      <div class="bulk-bar-left">
+        <span class="bulk-count" id="bulkCount">0 selected</span>
+      </div>
+      <div class="bulk-bar-right">
+        <select id="bulkStatusSelect" class="bulk-select">
+          <option value="">Change status to…</option>
+          <option value="completed">Completed</option>
+          <option value="started">In Progress</option>
+          <option value="not started">Not Started</option>
+        </select>
+        <button type="button" class="btn-bulk" id="applyBulkAction">Apply</button>
+        <button type="button" class="btn-bulk btn-bulk-cancel" id="cancelBulkAction">Cancel</button>
+      </div>
+    </div>
+
+    <div class="table-wrap">
+      <table id="usersTable">
+        <thead>
+          <tr>
+            <th class="checkbox-cell"><input type="checkbox" class="select-all-checkbox" id="selectAllCheckbox"></th>
+            <th class="sortable" data-column="first_name">Name</th>
+            <th class="sortable" data-column="primary_email">Email</th>
+            <th class="sortable" data-column="training_status">Training Status</th>
+            <th>Access</th>
+            <th class="sortable" data-column="updated_at">Last Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${users
+            .map(
+              (user) => `
+          <tr data-user-id="${user.id}" data-user-email="${user.primary_email}">
+            <td class="checkbox-cell"><input type="checkbox" class="user-checkbox" value="${user.primary_email}"></td>
+            <td class="user-name">${user.first_name || '-'}</td>
+            <td class="user-email">${user.primary_email || '-'}</td>
+            <td>
+              <select class="status-select status-${user.training_status.replace(' ', '-')}"
+                      data-email="${user.primary_email}"
+                      data-original-value="${user.training_status}">
+                <option value="not started" ${user.training_status === 'not started' ? 'selected' : ''}>Not Started</option>
+                <option value="started"     ${user.training_status === 'started'     ? 'selected' : ''}>In Progress</option>
+                <option value="completed"   ${user.training_status === 'completed'   ? 'selected' : ''}>Completed</option>
+              </select>
+            </td>
+            <td>
+              <span class="badge ${user.training_status === 'completed' ? 'badge-success' : 'badge-danger'}">
+                <span class="badge-dot"></span>
+                ${user.training_status === 'completed' ? 'Granted' : 'Denied'}
+              </span>
+            </td>
+            <td class="timestamp">${new Date(user.updated_at).toLocaleString()}</td>
+          </tr>`,
+            )
+            .join('')}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <script nonce="${scriptNonce}">
+    ${THEME_TOGGLE_JS}
+
+    async function updateTrainingStatus(email, newStatus, selectElement) {
+      const originalValue = selectElement.getAttribute('data-original-value');
+      if (newStatus === originalValue) return;
+      selectElement.disabled = true;
+      try {
+        const res = await fetch('/api/update-training', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin', body: JSON.stringify({ email, status: newStatus }),
         });
-    </script>
+        const result = await res.json();
+        if (result.success) {
+          selectElement.className = 'status-select status-' + newStatus.replace(' ', '-');
+          selectElement.setAttribute('data-original-value', newStatus);
+          const row = selectElement.closest('tr');
+          row.querySelector('.timestamp').textContent = new Date().toLocaleString();
+          const badge = row.querySelector('.badge');
+          if (newStatus === 'completed') { badge.className = 'badge badge-success'; badge.innerHTML = '<span class="badge-dot"></span>Granted'; }
+          else { badge.className = 'badge badge-danger'; badge.innerHTML = '<span class="badge-dot"></span>Denied'; }
+          updateStats();
+          showToast('success', 'Training status updated.');
+        } else {
+          selectElement.value = originalValue;
+          showToast('error', result.message || 'Failed to update training status.');
+        }
+      } catch (err) {
+        console.error(err); selectElement.value = originalValue;
+        showToast('error', 'Network error. Please try again.');
+      } finally { selectElement.disabled = false; }
+    }
+
+    function updateStats() {
+      let completed = 0, started = 0, notStarted = 0;
+      document.querySelectorAll('.status-select').forEach(s => {
+        if (s.value === 'completed') completed++;
+        else if (s.value === 'started') started++;
+        else notStarted++;
+      });
+      document.getElementById('completedCount').textContent = completed;
+      document.getElementById('startedCount').textContent = started;
+      document.getElementById('notStartedCount').textContent = notStarted;
+    }
+
+    async function syncOktaUsers() {
+      const btn = document.getElementById('syncButton');
+      const label = document.getElementById('syncStatus');
+      btn.disabled = true;
+      btn.innerHTML = '<span class="spinner"></span>Syncing\u2026';
+      label.textContent = 'Syncing users from Okta\u2026';
+      try {
+        const res = await fetch('/api/okta/sync', { method: 'POST', credentials: 'same-origin' });
+        const result = await res.json();
+        if (result.success) {
+          label.textContent = 'Sync completed: +' + result.results.added + ' added, ' + result.results.updated + ' updated, ' + result.results.skipped + ' skipped';
+          showToast('success', result.message);
+          setTimeout(() => window.location.reload(), 2000);
+        } else {
+          label.textContent = 'Sync failed';
+          showToast('error', result.message || 'Failed to sync users from Okta.');
+        }
+      } catch (err) {
+        console.error(err); label.textContent = 'Sync failed';
+        showToast('error', 'Network error during sync.');
+      } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M14 8A6 6 0 1 1 8 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M8 0l2.5 2.5L8 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Sync from Okta';
+        setTimeout(() => { label.textContent = 'Ready to sync users from Okta'; }, 5000);
+      }
+    }
+
+    function showToast(type, message) {
+      const s = document.getElementById('successToast');
+      const e = document.getElementById('errorToast');
+      s.classList.remove('visible'); e.classList.remove('visible');
+      if (type === 'success') {
+        document.getElementById('successText').textContent = message;
+        s.classList.add('visible'); setTimeout(() => s.classList.remove('visible'), 3000);
+      } else {
+        document.getElementById('errorText').textContent = message;
+        e.classList.add('visible'); setTimeout(() => e.classList.remove('visible'), 5000);
+      }
+    }
+
+    let currentSort = { column: null, direction: 'asc' };
+    function initSorting() {
+      document.querySelectorAll('th.sortable').forEach(th => {
+        th.addEventListener('click', () => sortTable(th.dataset.column, th));
+      });
+    }
+    function sortTable(column, headerEl) {
+      const tbody = document.querySelector('#usersTable tbody');
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      let dir = (currentSort.column === column && currentSort.direction === 'asc') ? 'desc' : 'asc';
+      document.querySelectorAll('th.sortable').forEach(th => th.classList.remove('asc', 'desc'));
+      headerEl.classList.add(dir);
+      rows.sort((a, b) => {
+        let av = getCellValue(a, column), bv = getCellValue(b, column);
+        if (column === 'updated_at') { av = new Date(av); bv = new Date(bv); }
+        else if (column === 'training_status') { const o = { completed:3, started:2, 'not started':1 }; av = o[av]||0; bv = o[bv]||0; }
+        else { av = av.toLowerCase(); bv = bv.toLowerCase(); }
+        return dir === 'asc' ? (av > bv ? 1 : -1) : (av < bv ? 1 : -1);
+      });
+      rows.forEach(r => tbody.appendChild(r));
+      currentSort = { column, direction: dir };
+    }
+    function getCellValue(row, column) {
+      switch (column) {
+        case 'first_name':      return row.querySelector('.user-name').textContent.trim();
+        case 'primary_email':   return row.querySelector('.user-email').textContent.trim();
+        case 'training_status': return row.querySelector('.status-select').value;
+        case 'updated_at':      return row.querySelector('.timestamp').textContent.trim();
+        default: return '';
+      }
+    }
+
+    function initFiltering() {
+      document.getElementById('statusFilter').addEventListener('change', applyFilters);
+      document.getElementById('searchFilter').addEventListener('input', debounce(applyFilters, 250));
+    }
+    function applyFilters() {
+      const status = document.getElementById('statusFilter').value;
+      const search = document.getElementById('searchFilter').value.toLowerCase();
+      const rows = document.querySelectorAll('#usersTable tbody tr');
+      let visible = 0;
+      rows.forEach(row => {
+        const s = row.querySelector('.status-select').value;
+        const n = row.querySelector('.user-name').textContent.toLowerCase();
+        const e = row.querySelector('.user-email').textContent.toLowerCase();
+        const match = (!status || s === status) && (!search || n.includes(search) || e.includes(search));
+        row.style.display = match ? '' : 'none';
+        if (match) visible++;
+      });
+      const counter = document.getElementById('filterCount');
+      if (visible === rows.length) { counter.style.display = 'none'; }
+      else { counter.style.display = 'block'; counter.textContent = 'Showing ' + visible + ' of ' + rows.length; }
+    }
+    function clearFilters() {
+      document.getElementById('statusFilter').value = '';
+      document.getElementById('searchFilter').value = '';
+      applyFilters();
+    }
+    function debounce(fn, wait) {
+      let t;
+      return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), wait); };
+    }
+
+    let selectedUsers = [];
+    function updateSelection() {
+      selectedUsers = Array.from(document.querySelectorAll('.user-checkbox')).filter(cb => cb.checked).map(cb => cb.value);
+      updateBulkUI();
+    }
+    function toggleAll(masterCb) {
+      const visible = Array.from(document.querySelectorAll('.user-checkbox')).filter(cb => cb.closest('tr').style.display !== 'none');
+      visible.forEach(cb => { cb.checked = masterCb.checked; cb.closest('tr').classList.toggle('selected', masterCb.checked); });
+      updateSelection();
+    }
+    function updateBulkUI() {
+      const bar = document.getElementById('bulkBar');
+      const count = document.getElementById('bulkCount');
+      const master = document.getElementById('selectAllCheckbox');
+      if (selectedUsers.length > 0) {
+        bar.classList.add('active');
+        count.textContent = selectedUsers.length + ' user' + (selectedUsers.length !== 1 ? 's' : '') + ' selected';
+        document.querySelectorAll('.user-checkbox').forEach(cb => { cb.closest('tr').classList.toggle('selected', cb.checked); });
+      } else {
+        bar.classList.remove('active'); master.checked = false; master.indeterminate = false;
+        document.querySelectorAll('tr.selected').forEach(r => r.classList.remove('selected'));
+      }
+      const visible = Array.from(document.querySelectorAll('.user-checkbox')).filter(cb => cb.closest('tr').style.display !== 'none');
+      const checked = visible.filter(cb => cb.checked);
+      if (checked.length === 0) { master.indeterminate = false; master.checked = false; }
+      else if (checked.length === visible.length) { master.indeterminate = false; master.checked = true; }
+      else { master.indeterminate = true; }
+    }
+    function clearSelection() {
+      document.querySelectorAll('.user-checkbox').forEach(cb => { cb.checked = false; });
+      document.getElementById('bulkStatusSelect').value = '';
+      updateSelection();
+    }
+    async function applyBulk() {
+      const newStatus = document.getElementById('bulkStatusSelect').value;
+      if (!newStatus || selectedUsers.length === 0) { showToast('error', 'Please select a status and at least one user.'); return; }
+      const applyBtn = document.getElementById('applyBulkAction');
+      applyBtn.disabled = true; applyBtn.textContent = 'Updating\u2026';
+      try {
+        const results = await Promise.all(selectedUsers.map(async email => {
+          const res = await fetch('/api/update-training', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin', body: JSON.stringify({ email, status: newStatus }),
+          });
+          return { email, data: await res.json() };
+        }));
+        const ok = results.filter(r => r.data.success);
+        const fail = results.filter(r => !r.data.success);
+        ok.forEach(({ email }) => {
+          const row = document.querySelector('tr[data-user-email="' + email + '"]');
+          if (!row) return;
+          const sel = row.querySelector('.status-select');
+          sel.value = newStatus; sel.className = 'status-select status-' + newStatus.replace(' ', '-');
+          sel.setAttribute('data-original-value', newStatus);
+          const badge = row.querySelector('.badge');
+          if (newStatus === 'completed') { badge.className = 'badge badge-success'; badge.innerHTML = '<span class="badge-dot"></span>Granted'; }
+          else { badge.className = 'badge badge-danger'; badge.innerHTML = '<span class="badge-dot"></span>Denied'; }
+        });
+        updateStats();
+        if (ok.length)   showToast('success', 'Updated ' + ok.length + ' user' + (ok.length !== 1 ? 's' : '') + ' to "' + newStatus + '".');
+        if (fail.length) showToast('error', 'Failed to update ' + fail.length + ' user' + (fail.length !== 1 ? 's' : '') + '.');
+        clearSelection();
+      } catch (err) {
+        console.error(err); showToast('error', 'Bulk update failed. Please try again.');
+      } finally { applyBtn.disabled = false; applyBtn.textContent = 'Apply'; }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      initSorting(); initFiltering();
+      document.getElementById('syncButton').addEventListener('click', syncOktaUsers);
+      document.getElementById('clearFiltersBtn').addEventListener('click', clearFilters);
+      document.getElementById('applyBulkAction').addEventListener('click', applyBulk);
+      document.getElementById('cancelBulkAction').addEventListener('click', clearSelection);
+      document.getElementById('selectAllCheckbox').addEventListener('change', function() { toggleAll(this); });
+      document.getElementById('usersTable').addEventListener('change', e => {
+        if (e.target.classList.contains('user-checkbox')) updateSelection();
+        if (e.target.classList.contains('status-select')) updateTrainingStatus(e.target.dataset.email, e.target.value, e.target);
+      });
+    });
+  </script>
+
 </body>
 </html>
-  `
+`
 
   const response = new Response(html, {
     headers: {
@@ -1404,19 +823,13 @@ export async function handleWebInterface(env: Env): Promise<Response> {
     },
   })
 
-  // Add CSP headers with nonces
-  const finalResponse = addCSPHeaders(response, env, scriptNonce, styleNonce)
-
-  return finalResponse
+  return addCSPHeaders(response, env, [scriptNonce, initNonce], styleNonce)
 }
 
-/**
- * Handle API request to update training status
- *
- * @param env - Environment bindings
- * @param request - HTTP request
- * @returns JSON response
- */
+// ---------------------------------------------------------------------------
+// Training update API (unchanged logic)
+// ---------------------------------------------------------------------------
+
 export async function handleUpdateTraining(
   env: Env,
   request: Request,
@@ -1425,380 +838,206 @@ export async function handleUpdateTraining(
     const body = (await request.json()) as UpdateTrainingBody
     const { email, status } = body
 
-    // Create secure headers for JSON responses
     const secureHeaders: Record<string, string> = {
       'content-type': 'application/json',
       ...createCSPHeaders(env),
     }
 
     if (!email || !status) {
-      const response: UpdateTrainingResponse = {
-        success: false,
-        message: 'Email and status are required',
-      }
-      return new Response(JSON.stringify(response), {
-        status: 400,
-        headers: secureHeaders,
-      })
+      return new Response(
+        JSON.stringify({ success: false, message: 'Email and status are required' } as UpdateTrainingResponse),
+        { status: 400, headers: secureHeaders },
+      )
     }
 
-    const validStatuses: TrainingStatus[] = [
-      'not started',
-      'started',
-      'completed',
-    ]
+    const validStatuses: TrainingStatus[] = ['not started', 'started', 'completed']
     if (!validStatuses.includes(status as TrainingStatus)) {
-      const response: UpdateTrainingResponse = {
-        success: false,
-        message: 'Invalid status value',
-      }
-      return new Response(JSON.stringify(response), {
-        status: 400,
-        headers: secureHeaders,
-      })
+      return new Response(
+        JSON.stringify({ success: false, message: 'Invalid status value' } as UpdateTrainingResponse),
+        { status: 400, headers: secureHeaders },
+      )
     }
 
-    const updated = await updateUserTrainingStatusByEmail(
-      env,
-      email,
-      status as TrainingStatus,
-    )
+    const updated = await updateUserTrainingStatusByEmail(env, email, status as TrainingStatus)
 
     if (updated) {
-      const response: UpdateTrainingResponse = {
-        success: true,
-        message: 'Training status updated successfully',
-      }
-      return new Response(JSON.stringify(response), {
-        headers: secureHeaders,
-      })
+      return new Response(
+        JSON.stringify({ success: true, message: 'Training status updated successfully' } as UpdateTrainingResponse),
+        { headers: secureHeaders },
+      )
     } else {
-      const response: UpdateTrainingResponse = {
-        success: false,
-        message: 'User not found or update failed',
-      }
-      return new Response(JSON.stringify(response), {
-        status: 404,
-        headers: secureHeaders,
-      })
+      return new Response(
+        JSON.stringify({ success: false, message: 'User not found or update failed' } as UpdateTrainingResponse),
+        { status: 404, headers: secureHeaders },
+      )
     }
   } catch (error) {
     console.error('Update training error:', error)
-    const response: UpdateTrainingResponse = {
-      success: false,
-      message: 'Internal server error',
-    }
-    return new Response(JSON.stringify(response), {
-      status: 500,
-      headers: {
-        'content-type': 'application/json',
-        ...createCSPHeaders(env),
-      },
-    })
+    return new Response(
+      JSON.stringify({ success: false, message: 'Internal server error' } as UpdateTrainingResponse),
+      { status: 500, headers: { 'content-type': 'application/json', ...createCSPHeaders(env) } },
+    )
   }
 }
 
-/**
- * Handle GET request for the system overview (root path)
- *
- * @param env - Environment bindings
- * @returns HTML response showing system details
- */
+// ---------------------------------------------------------------------------
+// System Overview (/)
+// ---------------------------------------------------------------------------
+
 export async function handleSystemOverview(env: Env): Promise<Response> {
-  // Generate nonces for inline scripts and styles
   const styleNonce = generateNonce()
+  const scriptNonce = generateNonce()
+  const initNonce = generateNonce()
 
   const html = `
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Training Compliance Gateway</title>
-    <style nonce="${styleNonce}">
-        /* Professional Design System - Gateway Style */
-        :root {
-            --accent: #F38020;         /* Cloudflare Orange */
-            --cta: #2563EB;            /* Blue CTA */
-            --cta-hover: #1E40AF;
-            --surface: #ffffff;        /* Card & modal surface */
-            --muted: #6B7280;          /* Muted text */
-            --border: #E5E7EB;         /* Subtle borders */
-            --panel: #F8FAFC;          /* Light panels inside card */
-            --shadow: 0 12px 30px rgba(2,6,23,.18);
-            --radius: 16px;
-            --text-primary: #111827;
-            --text-secondary: #374151;
-        }
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Training Compliance Gateway</title>
+  ${THEME_INIT_SCRIPT(initNonce)}
+  <style nonce="${styleNonce}">
+    ${KUMO_TOKENS}
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            background: radial-gradient(1200px 800px at 50% -10%, #111827 0%, #0f172a 60%);
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--text-primary);
-            line-height: 1.6;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-            padding: 24px;
-        }
+    body {
+      font-family: var(--kumo-font);
+      background: var(--kumo-canvas);
+      min-height: 100vh;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      color: var(--kumo-text-default); line-height: 1.5;
+      -webkit-font-smoothing: antialiased; padding: 24px;
+      transition: background 0.2s, color 0.2s;
+    }
 
-        .container {
-            background: var(--surface);
-            border-radius: var(--radius);
-            box-shadow: var(--shadow);
-            max-width: 580px;
-            width: 100%;
-            margin: 0;
-            overflow: hidden;
-        }
+    .card {
+      background: var(--kumo-base); border: 1px solid var(--kumo-hairline);
+      border-radius: var(--kumo-radius-xl); box-shadow: var(--kumo-shadow-lg);
+      max-width: 560px; width: 100%; overflow: hidden;
+    }
 
-        .header {
-            background: var(--accent);
-            color: #fff;
-            padding: 28px 28px 24px;
-            text-align: center;
-        }
+    .card-header {
+      background: var(--kumo-orange); padding: 28px 28px 22px;
+      text-align: center; color: #fff; position: relative;
+    }
+    .card-header-icon { display: block; font-size: 36px; margin-bottom: 12px; line-height: 1; }
+    .card-header h1 { font-size: 22px; font-weight: 700; letter-spacing: 0.2px; margin-bottom: 6px; }
+    .card-header p  { font-size: 14px; opacity: 0.92; line-height: 1.5; }
 
-        .header .icon {
-            font-size: 48px;
-            display: block;
-            margin-bottom: 16px;
-            line-height: 1;
-        }
+    ${THEME_TOGGLE_CSS}
+    .theme-toggle {
+      position: absolute; top: 14px; right: 14px;
+      background: rgba(255,255,255,.2); border-color: rgba(255,255,255,.3); color: #fff;
+    }
+    .theme-toggle:hover { background: rgba(255,255,255,.35); border-color: rgba(255,255,255,.5); color: #fff; }
 
-        .header h1 {
-            font-size: 28px;
-            font-weight: 700;
-            letter-spacing: 0.2px;
-            margin-bottom: 8px;
-        }
+    .card-body { padding: 24px 28px; }
 
-        .header p {
-            font-size: 15px;
-            opacity: 0.95;
-            line-height: 1.5;
-        }
+    .status-banner {
+      display: flex; align-items: center; gap: 10px; padding: 10px 14px;
+      background: var(--kumo-success-tint); border: 1px solid var(--kumo-success-border);
+      border-radius: var(--kumo-radius); margin-bottom: 24px;
+    }
+    .status-dot {
+      width: 10px; height: 10px; border-radius: 50%; background: var(--kumo-success);
+      box-shadow: 0 0 0 3px rgba(22,163,74,.2); animation: pulse 2s infinite; flex-shrink: 0;
+    }
+    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.6} }
+    .status-banner span { font-size: 14px; font-weight: 600; color: var(--kumo-success); }
 
-        .content {
-            padding: 28px;
-        }
+    .section-title {
+      font-size: 13px; font-weight: 600; color: var(--kumo-text-subtle);
+      text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px;
+    }
 
-        .system-status {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            margin-bottom: 24px;
-            padding: 12px 16px;
-            background: #F0FDF4;
-            border: 1px solid #BBF7D0;
-            border-radius: 8px;
-        }
+    .endpoints { display: flex; flex-direction: column; gap: 8px; margin-bottom: 20px; }
+    .endpoint-row {
+      display: flex; align-items: center; gap: 12px; padding: 10px 12px;
+      background: var(--kumo-tint); border: 1px solid var(--kumo-hairline);
+      border-radius: var(--kumo-radius);
+    }
+    .method-badge {
+      font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 4px;
+      min-width: 44px; text-align: center; flex-shrink: 0;
+    }
+    .method-get  { background: var(--kumo-info-tint);   color: var(--kumo-info);   border: 1px solid var(--kumo-info-border); }
+    .method-post { background: var(--kumo-danger-tint); color: var(--kumo-danger); border: 1px solid var(--kumo-danger-border); }
+    .endpoint-path { font-family: var(--kumo-font-mono); font-size: 13px; font-weight: 600; color: var(--kumo-text-default); min-width: 72px; flex-shrink: 0; }
+    .endpoint-desc { font-size: 13px; color: var(--kumo-text-subtle); }
 
-        .status-indicator {
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            background: #16A34A;
-            box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.2);
-            animation: pulse 2s infinite;
-        }
+    .notice {
+      display: flex; gap: 10px; padding: 12px 14px;
+      background: var(--kumo-warning-tint); border: 1px solid var(--kumo-warning-border);
+      border-radius: var(--kumo-radius); margin-bottom: 20px;
+    }
+    .notice-icon { font-size: 16px; flex-shrink: 0; margin-top: 1px; }
+    .notice-text { font-size: 13px; color: var(--kumo-warning); line-height: 1.5; }
+    .notice-text strong { font-weight: 600; }
 
-        @keyframes pulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.7; }
-        }
+    .card-footer {
+      border-top: 1px solid var(--kumo-hairline); padding: 14px 28px;
+      text-align: center; background: var(--kumo-tint);
+    }
+    .card-footer span { font-size: 12px; color: var(--kumo-text-inactive); font-weight: 500; }
 
-        .status-text {
-            color: #166534;
-            font-weight: 600;
-            font-size: 16px;
-        }
-
-        .endpoints-section {
-            margin-bottom: 24px;
-        }
-
-        .endpoints-section h3 {
-            color: var(--text-primary);
-            font-size: 18px;
-            font-weight: 600;
-            margin-bottom: 16px;
-        }
-
-        .endpoints-grid {
-            display: grid;
-            gap: 12px;
-        }
-
-        .endpoint-card {
-            display: flex;
-            align-items: center;
-            gap: 16px;
-            padding: 12px 16px;
-            background: var(--panel);
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
-            font-size: 14px;
-        }
-
-        .endpoint-method {
-            font-weight: 700;
-            font-size: 12px;
-            padding: 4px 8px;
-            border-radius: 4px;
-            text-align: center;
-            min-width: 48px;
-        }
-
-        .endpoint-method.get {
-            background: #DBEAFE;
-            color: #1E40AF;
-        }
-
-        .endpoint-method.post {
-            background: #FEE2E2;
-            color: #DC2626;
-        }
-
-        .endpoint-path {
-            font-weight: 600;
-            color: var(--text-primary);
-            min-width: 80px;
-        }
-
-        .endpoint-desc {
-            color: var(--text-secondary);
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            font-size: 14px;
-        }
-
-        .system-notice {
-            display: flex;
-            gap: 12px;
-            padding: 16px;
-            background: #FEF3C7;
-            border: 1px solid #FDE68A;
-            border-radius: 8px;
-            margin-bottom: 24px;
-        }
-
-        .notice-icon {
-            font-size: 20px;
-            flex-shrink: 0;
-        }
-
-        .notice-content {
-            color: #92400E;
-            font-size: 14px;
-            line-height: 1.5;
-        }
-
-        .notice-content strong {
-            font-weight: 600;
-        }
-
-        .powered-by {
-            text-align: center;
-            padding: 16px 0;
-            border-top: 1px solid var(--border);
-            margin-top: 8px;
-        }
-
-        .powered-by span {
-            color: var(--text-secondary);
-            font-size: 14px;
-            font-weight: 500;
-        }
-
-        @media (max-width: 600px) {
-            .container {
-                margin: 12px;
-            }
-
-            .content {
-                padding: 22px;
-            }
-
-            .header {
-                padding: 24px;
-            }
-
-            .header h1 {
-                font-size: 24px;
-            }
-
-            .endpoint-card {
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 8px;
-            }
-
-            .endpoint-method {
-                align-self: flex-start;
-            }
-        }
-    </style>
+    @media (max-width: 600px) {
+      body { padding: 16px; }
+      .card-header { padding: 24px 20px 20px; }
+      .card-body { padding: 20px; }
+      .endpoint-row { flex-direction: column; align-items: flex-start; gap: 6px; }
+    }
+  </style>
 </head>
 <body>
-    <div class="container">
-        <div class="header">
-            <span class="icon">🛡️</span>
-            <h1>Training Compliance Gateway</h1>
-            <p>This is a Cloudflare Access External Evaluation Worker that enforces training completion requirements for Zero Trust Security.</p>
-        </div>
-
-        <div class="content">
-            <div class="system-status">
-                <span class="status-indicator"></span>
-                <span class="status-text">Worker is running and ready to process access requests</span>
-            </div>
-
-            <div class="endpoints-section">
-                <h3>Available Endpoints:</h3>
-                <div class="endpoints-grid">
-                    <div class="endpoint-card">
-                        <div class="endpoint-method get">GET</div>
-                        <div class="endpoint-path">/keys</div>
-                        <div class="endpoint-desc">Public key endpoint for Cloudflare Access</div>
-                    </div>
-                    <div class="endpoint-card">
-                        <div class="endpoint-method post">POST</div>
-                        <div class="endpoint-path">/</div>
-                        <div class="endpoint-desc">External evaluation endpoint (used by Access)</div>
-                    </div>
-                    <div class="endpoint-card">
-                        <div class="endpoint-method get">GET</div>
-                        <div class="endpoint-path">/admin</div>
-                        <div class="endpoint-desc">Training management dashboard (Access protected)</div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="system-notice">
-                <div class="notice-icon">⚠️</div>
-                <div class="notice-content">
-                    <strong>Note:</strong> This endpoint is designed to receive POST requests with JWT tokens from Cloudflare Access. Direct browser access shows this informational page instead of the JSON parsing error.
-                </div>
-            </div>
-
-            <div class="powered-by">
-                <span>Powered by Cloudflare Workers</span>
-            </div>
-        </div>
+  <div class="card">
+    <div class="card-header">
+      ${THEME_TOGGLE_BTN}
+      <span class="card-header-icon" aria-hidden="true">🛡️</span>
+      <h1>Training Compliance Gateway</h1>
+      <p>Cloudflare Access External Evaluation Worker enforcing training completion for Zero Trust security.</p>
     </div>
+    <div class="card-body">
+      <div class="status-banner">
+        <div class="status-dot"></div>
+        <span>Worker is running and ready</span>
+      </div>
+      <p class="section-title">Available Endpoints</p>
+      <div class="endpoints">
+        <div class="endpoint-row">
+          <span class="method-badge method-get">GET</span>
+          <span class="endpoint-path">/keys</span>
+          <span class="endpoint-desc">Public key endpoint for Cloudflare Access</span>
+        </div>
+        <div class="endpoint-row">
+          <span class="method-badge method-post">POST</span>
+          <span class="endpoint-path">/</span>
+          <span class="endpoint-desc">External evaluation endpoint (used by Access)</span>
+        </div>
+        <div class="endpoint-row">
+          <span class="method-badge method-get">GET</span>
+          <span class="endpoint-path">/admin</span>
+          <span class="endpoint-desc">Training management dashboard (Access protected)</span>
+        </div>
+      </div>
+      <div class="notice">
+        <span class="notice-icon">⚠️</span>
+        <p class="notice-text">
+          <strong>Note:</strong> This endpoint is designed to receive POST requests with JWT tokens from Cloudflare Access. Direct browser access shows this informational page.
+        </p>
+      </div>
+    </div>
+    <div class="card-footer">
+      <span>Powered by Cloudflare Workers</span>
+    </div>
+  </div>
+  <script nonce="${scriptNonce}">
+    ${THEME_TOGGLE_JS}
+  </script>
 </body>
 </html>
-  `
+`
 
   const response = new Response(html, {
     headers: {
@@ -1807,6 +1046,5 @@ export async function handleSystemOverview(env: Env): Promise<Response> {
     },
   })
 
-  // Add CSP headers with nonces
-  return addCSPHeaders(response, env, null, styleNonce)
+  return addCSPHeaders(response, env, [scriptNonce, initNonce], styleNonce)
 }

--- a/src/security/csp.ts
+++ b/src/security/csp.ts
@@ -82,16 +82,23 @@ export const CSP_CONFIG = {
  * Build CSP header value from configuration
  *
  * @param config - CSP configuration object
- * @param scriptNonce - Nonce for inline scripts
+ * @param scriptNonces - One or more nonces for inline scripts
  * @param styleNonce - Nonce for inline styles
  * @returns CSP header value
  */
 export function buildCSPHeader(
   config: CSPConfiguration,
-  scriptNonce: string | null = null,
+  scriptNonces: string | string[] | null = null,
   styleNonce: string | null = null,
 ): string {
   const directives: string[] = []
+
+  // Normalise to array for uniform handling
+  const scriptNonceList: string[] = scriptNonces
+    ? Array.isArray(scriptNonces)
+      ? scriptNonces
+      : [scriptNonces]
+    : []
 
   for (const [directive, values] of Object.entries(config)) {
     if (typeof values === 'boolean') {
@@ -108,8 +115,8 @@ export function buildCSPHeader(
     const directiveValues = [...values]
 
     // Add nonces for script and style sources
-    if (directive === 'script-src' && scriptNonce) {
-      directiveValues.push(`'nonce-${scriptNonce}'`)
+    if (directive === 'script-src' && scriptNonceList.length > 0) {
+      scriptNonceList.forEach((n) => directiveValues.push(`'nonce-${n}'`))
     }
     if (directive === 'style-src' && styleNonce) {
       directiveValues.push(`'nonce-${styleNonce}'`)
@@ -139,17 +146,17 @@ export function getCSPConfig(env: Env): CSPConfiguration {
  * Create CSP headers for HTTP responses
  *
  * @param env - Environment bindings
- * @param scriptNonce - Nonce for inline scripts
+ * @param scriptNonces - One or more nonces for inline scripts
  * @param styleNonce - Nonce for inline styles
  * @returns Headers object with CSP
  */
 export function createCSPHeaders(
   env: Env,
-  scriptNonce: string | null = null,
+  scriptNonces: string | string[] | null = null,
   styleNonce: string | null = null,
 ): Record<string, string> {
   const config = getCSPConfig(env)
-  const cspHeader = buildCSPHeader(config, scriptNonce, styleNonce)
+  const cspHeader = buildCSPHeader(config, scriptNonces, styleNonce)
 
   return {
     'Content-Security-Policy': cspHeader,
@@ -166,18 +173,18 @@ export function createCSPHeaders(
  *
  * @param response - Original response
  * @param env - Environment bindings
- * @param scriptNonce - Nonce for inline scripts
+ * @param scriptNonces - One or more nonces for inline scripts
  * @param styleNonce - Nonce for inline styles
  * @returns Response with CSP headers
  */
 export function addCSPHeaders(
   response: Response,
   env: Env,
-  scriptNonce: string | null = null,
+  scriptNonces: string | string[] | null = null,
   styleNonce: string | null = null,
 ): Response {
   const headers = new Headers(response.headers)
-  const cspHeaders = createCSPHeaders(env, scriptNonce, styleNonce)
+  const cspHeaders = createCSPHeaders(env, scriptNonces, styleNonce)
 
   // Add all security headers
   for (const [key, value] of Object.entries(cspHeaders)) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,8 +2,8 @@
   // Cloudflare Access External Evaluation Worker with Training Certification System
   "name": "cloudflare-access-training-evaluator",
   // Security: Disable public endpoints
-  "workers_dev": false,       // Disables *.workers.dev URLs
-  "preview_urls": false,      // Disables version preview URLs
+  "workers_dev": false, // Disables *.workers.dev URLs
+  "preview_urls": false, // Disables version preview URLs
   "compatibility_date": "2024-08-06",
   "main": "src/index.ts",
 
@@ -13,8 +13,8 @@
   "kv_namespaces": [
     {
       "binding": "KEY_STORAGE",
-      "id": "1653d25211e2409a8ac19aff95ac4353"
-    }
+      "id": "1653d25211e2409a8ac19aff95ac4353",
+    },
   ],
 
   // D1 Database for training completion status tracking
@@ -24,8 +24,8 @@
     {
       "binding": "DB",
       "database_name": "training-completion-status-db",
-      "database_id": "6867bf4a-f611-43ce-8100-d36a3bb67adc"
-    }
+      "database_id": "6867bf4a-f611-43ce-8100-d36a3bb67adc",
+    },
   ],
 
   // Environment Variables
@@ -33,22 +33,30 @@
   "vars": {
     "TEAM_DOMAIN": "macharpe.cloudflareaccess.com",
     "ADMIN_DOMAIN": "training-status.macharpe.com",
-    "OKTA_DOMAIN": "trial-6147933.okta.com",
-    "DEBUG": false
+    "OKTA_DOMAIN": "integrator-2757404.okta.com",
+    "DEBUG": false,
   },
+
+  // Route configuration
+  "routes": [
+    {
+      "pattern": "training-status.macharpe.com/*",
+      "zone_name": "macharpe.com",
+    },
+  ],
 
   // Observability - provides Worker analytics and logs
   "observability": {
-    "enabled": true
+    "enabled": true,
   },
 
   // Smart Placement for optimal performance and reduced latency
   "placement": {
-    "mode": "smart"
-  }
+    "mode": "smart",
+  },
 
   // Secrets Configuration (use wrangler secret put commands):
-  // 
+  //
   // Required for Okta integration:
   // wrangler secret put OKTA_API_TOKEN     // Your Okta API token
   //


### PR DESCRIPTION
## Summary

- Rebuilt all four HTML pages using Cloudflare's Kumo semantic token system (Admin Dashboard, System Overview, External Eval fallback, Access Denied)
- Added dark/light mode toggle with flash-prevention init script, `localStorage` persistence, and `prefers-color-scheme` as default — on all pages
- Fixed a CSP bug that was breaking all inline JS (buttons, Okta sync, theme toggle) — `buildCSPHeader` now accepts `string | string[]` for script nonces so multiple nonces can be allowlisted correctly

## Changes

### UI Rebuild
- All CSS rewritten with Kumo design tokens as CSS custom properties (`--kumo-canvas`, `--kumo-base`, `--kumo-text-*`, `--kumo-success-*`, etc.)
- `[data-mode="dark"]` block overrides all tokens for dark mode — no `dark:` variants, no extra classes
- Admin Dashboard: sticky header with CF dot logo, stat cards, pill status selects, clean sortable table, dark bulk-actions bar
- Card pages: centred card layout, orange/red header bar, method badges (GET/POST), status banners, warning notice boxes

### Dark / Light Mode
- Moon/sun SVG toggle button on all 4 pages
- Flash-prevention `<script>` runs before CSS to avoid white flash on dark-mode users
- Preference stored in `localStorage`, falls back to `prefers-color-scheme`

### Bug Fix
- `buildCSPHeader` / `createCSPHeaders` / `addCSPHeaders` in `src/security/csp.ts` updated to accept `string | string[] | null` for script nonces
- Call sites in `web.ts` and `index.ts` updated to pass `[scriptNonce, initNonce]` arrays

### Infrastructure
- `wrangler` bumped `4.28.0` → `4.86.0`
- Worker route `training-status.macharpe.com/*` added to `wrangler.jsonc`
- `package.json` version bumped to `3.0.0`
- `CHANGELOG.md` and `README.md` updated

## Testing
- TypeScript type-check passes with zero errors
- Deployed to `training-status.macharpe.com` — Version ID `bda407ca`